### PR TITLE
remove use_utils_prod

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -98,7 +98,6 @@ These three functions adds one file each which contain a series of functions tha
 ```{r eval=FALSE}
 golem::use_utils_ui()
 golem::use_utils_server()
-golem::use_utils_prod()
 ```
 
 Somes JS functions can also be used inside your shiny app with: 

--- a/inst/shinyexample/dev/01_start.R
+++ b/inst/shinyexample/dev/01_start.R
@@ -45,7 +45,7 @@ golem::use_recommended_dep()
 ## 1. Add various tools
 
 golem::use_utils_ui()
-golem::use_utils_prod()
+golem::use_utils_server()
 
 # If you want to change the default favicon
 golem::use_favicon( path = "path/to/favicon")


### PR DESCRIPTION
As requested, the pull request to remove mention of the deprecated function `use_utils_prod()`