### PR TITLE
add includeRmarkdown to use_utils_ui template

### DIFF
--- a/inst/utils/golem_utils_ui.R
+++ b/inst/utils/golem_utils_ui.R
@@ -163,7 +163,6 @@ enurl <- function(url, text){
   tags$a(href = url, text)
 }
 
-
 # Columns wrappers
 # 
 # These are convenient wrappers around 
@@ -211,3 +210,31 @@ col_1 <- function(...){
   column(1, ...)
 }
 
+#' Include Content From a File
+#' 
+#' Load rendered RMarkdown from a file and turn into HTML.
+#' 
+#' @rdname includeRMarkdown
+#' @export
+#' 
+#' @importFrom rmarkdown render
+#' @importFrom markdown markdownToHTML
+#' @importFrom htmltools HTML
+includeRMarkdown <- function(path){
+  
+  md <- tempfile(fileext = '.md')
+  
+  on.exit(unlink(md),add = TRUE)
+  
+  rmarkdown::render(
+    path,
+    output_format = 'md_document',
+    output_dir = tempdir(),
+    output_file = md,quiet = TRUE)
+  
+  html <- markdown::markdownToHTML(md, fragment.only = TRUE)
+  
+  Encoding(html) <- "UTF-8"
+  
+  return(HTML(html))
+}


### PR DESCRIPTION
A function works like `shiny::includeMarkdown` but for RMarkdown files.

It is in the `inst/utils/use_utils_ui.R` so it will get loaded into the target package only with `use_*`.

This will make the app webpages more flexible for content in the inst/app/www files

eg [tidytuesday201942](https://github.com/ColinFay/tidytuesday201942/tree/master/inst/app/www)