### PR TITLE
#266 add http_proxy and https_proxy parameters in add_dockerfile

### DIFF
--- a/R/add_deploy_helpers.R
+++ b/R/add_deploy_helpers.R
@@ -122,6 +122,8 @@ add_shinyserver_file <- function(
 #' @param sysreqs boolean to check the system requirements    
 #' @param repos character vector, the base URL of the repositories  
 #' @param expand boolean, if `TRUE` each system requirement will be known his own RUN line
+#' @param http_proxy proxy address (http)
+#' @param https_proxy proxy address (https)
 #' @export
 #' @rdname dockerfiles
 #' @importFrom desc desc_get_deps
@@ -156,7 +158,9 @@ add_dockerfile <- function(
   host = "0.0.0.0",
   sysreqs = TRUE,
   repos = "https://cran.rstudio.com/",
-  expand = FALSE
+  expand = FALSE,
+  http_proxy = NULL,
+  https_proxy = http_proxy
   # ,  function_to_launch = "run_app"
 ) {
   
@@ -168,7 +172,7 @@ add_dockerfile <- function(
   
   
   
-  dock <- dock_from_desc(path = path, FROM = from, AS = as, sysreqs = sysreqs, repos = repos,expand = expand)
+  dock <- dock_from_desc(path = path, FROM = from, AS = as, sysreqs = sysreqs, repos = repos,expand = expand,http_proxy = http_proxy,https_proxy = https_proxy)
   dock$EXPOSE(port)
   dock$CMD(
     glue::glue(
@@ -301,6 +305,8 @@ alert_build <- function(path, output){
 #' @param sysreqs boolean to check the system requirements    
 #' @param repos character vector, the base URL of the repositories  
 #' @param expand boolean, if `TRUE` each system requirement will be known his own RUN line
+#' @param http_proxy proxy address (http)
+#' @param https_proxy proxy address (https)
 #'
 #' @importFrom utils installed.packages packageVersion
 #' @importFrom remotes dev_package_deps
@@ -318,7 +324,9 @@ dock_from_desc <- function(
   AS = NULL,
   sysreqs = TRUE,
   repos = "https://cran.rstudio.com/",
-  expand = FALSE
+  expand = FALSE,
+  http_proxy = NULL,
+  https_proxy = http_proxy
 ){
   
  
@@ -358,6 +366,15 @@ dock_from_desc <- function(
   
   
   dock <- dockerfiler::Dockerfile$new(FROM = FROM)
+  
+  if ( !is.null(http_proxy) ){
+    dock$RUN(glue::glue("echo \"Sys.setenv(http_proxy= '{http_proxy}');Sys.setenv(HTTP_PROXY= '{http_proxy}')\">> /usr/local/lib/R/etc/Rprofile.site"))
+  }
+  if ( !is.null(https_proxy) ){
+    dock$RUN(glue::glue("echo \"Sys.setenv(https_proxy= '{https_proxy}');Sys.setenv(HTTPS_PROXY= '{https_proxy}')\">> /usr/local/lib/R/etc/Rprofile.site"))
+  }
+  
+  
   
   if (length(system_requirement)>0){
     

--- a/man/dock_from_desc.Rd
+++ b/man/dock_from_desc.Rd
@@ -7,7 +7,7 @@
 dock_from_desc(path = "DESCRIPTION", FROM = paste0("rocker/r-ver:",
   R.Version()$major, ".", R.Version()$minor), AS = NULL,
   sysreqs = TRUE, repos = "https://cran.rstudio.com/",
-  expand = FALSE)
+  expand = FALSE, http_proxy = NULL, https_proxy = http_proxy)
 }
 \arguments{
 \item{path}{path to the DESCRIPTION file to use as an input.}
@@ -22,6 +22,10 @@ with \code{R.Version()$major} and \code{R.Version()$minor}.}
 \item{repos}{character vector, the base URL of the repositories}
 
 \item{expand}{boolean, if \code{TRUE} each system requirement will be known his own RUN line}
+
+\item{http_proxy}{proxy address (http)}
+
+\item{https_proxy}{proxy address (https)}
 }
 \description{
 Create Dockerfile from DESCRIPTION

--- a/man/dockerfiles.Rd
+++ b/man/dockerfiles.Rd
@@ -10,7 +10,8 @@ add_dockerfile(path = "DESCRIPTION", output = "Dockerfile",
   pkg = get_golem_wd(), from = paste0("rocker/r-ver:",
   R.Version()$major, ".", R.Version()$minor), as = NULL, port = 80,
   host = "0.0.0.0", sysreqs = TRUE,
-  repos = "https://cran.rstudio.com/", expand = FALSE)
+  repos = "https://cran.rstudio.com/", expand = FALSE,
+  http_proxy = NULL, https_proxy = http_proxy)
 
 add_dockerfile_shinyproxy(path = "DESCRIPTION", output = "Dockerfile",
   pkg = get_golem_wd(), from = paste0("rocker/r-ver:",
@@ -47,6 +48,10 @@ Default is 0.0.0.0.}
 \item{repos}{character vector, the base URL of the repositories}
 
 \item{expand}{boolean, if \code{TRUE} each system requirement will be known his own RUN line}
+
+\item{http_proxy}{proxy address (http)}
+
+\item{https_proxy}{proxy address (https)}
 }
 \description{
 Build a container containing your Shiny App. \code{add_dockerfile()} creates

--- a/tests/testthat/test-add_dockerfile.R
+++ b/tests/testthat/test-add_dockerfile.R
@@ -1,5 +1,35 @@
 context("function add_dockerfile")
 
+
+test_that("http_proxy", {
+  with_dir(pkg, {
+    unlink("Dockerfile", force = TRUE)
+    output <- testthat::capture_output(add_dockerfile(pkg = pkg, sysreqs = FALSE,http_proxy = "coucou"))
+    expect_exists("Dockerfile")
+    test <- stringr::str_detect(output, "Dockerfile created at Dockerfile")
+    expect_true(test)
+     
+    expect_true(any(stringr::str_detect(readLines(con = file("Dockerfile")),"http_proxy= 'coucou'")))
+    
+    remove_files("Dockerfile")
+  })
+})
+
+test_that("https_proxy", {
+  with_dir(pkg, {
+    unlink("Dockerfile", force = TRUE)
+    output <- testthat::capture_output(add_dockerfile(pkg = pkg, sysreqs = FALSE,https_proxy = "coucou"))
+    expect_exists("Dockerfile")
+    test <- stringr::str_detect(output, "Dockerfile created at Dockerfile")
+    expect_true(test)
+     
+    expect_true(any(stringr::str_detect(readLines(con = file("Dockerfile")),"https_proxy= 'coucou'")))
+    
+    remove_files("Dockerfile")
+  })
+})
+
+
 test_that("add_dockerfile", {
   with_dir(pkg, {
     unlink("Dockerfile", force = TRUE)


### PR DESCRIPTION
You can now use :
`golem::add_dockerfile(http_proxy = "http://")`

to passe proxy parameters directly to the container