### PR TITLE
remove blank space from dockerfile shinyproxy

### DIFF
--- a/R/add_deploy_helpers.R
+++ b/R/add_deploy_helpers.R
@@ -206,7 +206,7 @@ add_dockerfile_shinyproxy <- function(
   
   dock$EXPOSE(3838)
   dock$CMD(glue::glue(
-    " [\"R\", \"-e\", \"options('shiny.port'=3838,shiny.host='0.0.0.0'); {read.dcf(path)[1]}::run_app()\"]"
+    " [\"R\", \"-e\", \"options('shiny.port'=3838,shiny.host='0.0.0.0');{read.dcf(path)[1]}::run_app()\"]"
   ))
   dock$write(output)
   


### PR DESCRIPTION
There is a blank space in the function that creates the shinyproxy dockerfile that results in the argument "run_app()" to be ignored in the CMD instruction.