### PR TITLE
Improve overwriting logic and logging in `create_golem`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 + `use_external_*()` function don't open files by default (#404)
 
++ `create_golem()` function now has an `overwrite` argument (#424, @antoine-sachet)
+
 ## Breaking changes
 
 ## Bug fix

--- a/man/create_golem.Rd
+++ b/man/create_golem.Rd
@@ -4,8 +4,15 @@
 \alias{create_golem}
 \title{Create a package for Shiny App using golem}
 \usage{
-create_golem(path, check_name = TRUE, open = TRUE,
-  package_name = basename(path), without_comments = FALSE, ...)
+create_golem(
+  path,
+  check_name = TRUE,
+  open = TRUE,
+  package_name = basename(path),
+  without_comments = FALSE,
+  overwrite = NULL,
+  ...
+)
 }
 \arguments{
 \item{path}{Name of the folder to create the package in. This will also be
@@ -20,6 +27,8 @@ the package name from being checked.}
 not explicitly given, then \code{basename(getwd())} will be used.}
 
 \item{without_comments}{Boolean start project without golem comments}
+
+\item{overwrite}{Boolean overwrite directory if path already exists. \code{NULL} (default) to prompt user.}
 
 \item{...}{not used}
 }


### PR DESCRIPTION
`create_golem` now has an extra optional argument `overwrite` which can take 3 values:
- `NULL` (default) prompts the user if the session is interactive, otherwise behaves like FALSE
- `TRUE` overwrites if needed
- `FALSE` stops if the directory already exists.

The other option is to just have TRUE/FALSE, and fail if the directory exists with overwrite = FALSE (default), with no prompting. A bit less user-friendly but more in line with other packages I have seen.

Close #424.