### PR TITLE
## New Functions: make_action_button function (golem_utils_ui.R)

### DIFF
--- a/inst/utils/golem_utils_ui.R
+++ b/inst/utils/golem_utils_ui.R
@@ -294,6 +294,46 @@ col_1 <- function(...){
   column(1, ...)
 }
 
+
+
+#' Make the current tag behave like an action button
+#' 
+#' Only works with compatible tags like button or links
+#'
+#' @param tag Any compatible tag.
+#' @param inputId Unique id. This will host the input value to be used
+#' on the server side.
+#'
+#' @return The modified tag with an extra id and the action button class.
+#' @noRd
+#'
+#' @examples
+#' if (interactive()) {
+#'  library(shiny)
+#'  
+#'  link <- a(href = "#", "My super link", style = "color: lightblue;") 
+#'  
+#'  ui <- fluidPage(
+#'   make_action_button(link, inputId = "mylink")
+#'  )
+#'  
+#'  server <- function(input, output, session) {
+#'    observeEvent(input$mylink, {
+#'     showNotification("Pouic!")
+#'    })
+#'  }
+#'  
+#'  shinyApp(ui, server)
+#'  
+#' }
+make_action_button <- function(tag, inputId) {
+  # listen to the shiny action button input binding
+  tag$attribs$class <- paste(tag$attribs$class, "action-button")
+  tag$attribs$id <- inputId
+  tag
+}
+
+
 # UNCOMMENT AND USE 
 # 
 # usethis::use_package("markdown")

--- a/inst/utils/golem_utils_ui.R
+++ b/inst/utils/golem_utils_ui.R
@@ -348,21 +348,15 @@ make_action_button <- function(tag, inputId = NULL) {
       )
     } else {
       tag$attribs$id <- inputId
-      cat_green_tick("Adding id attribute ...")
     }
-  } else {
-    cat_green_tick("Using the internal tag id. Nothing to do on your side.")
-  }
+  } 
   
   # handle class
   if (is.null(tag$attribs$class)) {
     tag$attribs$class <- "action-button"
-    cat_green_tick("Adding action-button class ...")
   } else {
     tag$attribs$class <- paste(tag$attribs$class, "action-button") 
   }
-  
-  cat_green_tick("Ready to go ...")
   # return tag
   tag
 }

--- a/inst/utils/golem_utils_ui.R
+++ b/inst/utils/golem_utils_ui.R
@@ -326,10 +326,44 @@ col_1 <- function(...){
 #'  shinyApp(ui, server)
 #'  
 #' }
-make_action_button <- function(tag, inputId) {
-  # listen to the shiny action button input binding
-  tag$attribs$class <- paste(tag$attribs$class, "action-button")
-  tag$attribs$id <- inputId
+make_action_button <- function(tag, inputId = NULL) {
+  # some obvious checks
+  if (!inherits(tag, "shiny.tag")) stop("Must provide a shiny tag.")
+  if (!is.null(tag$attribs$class)) {
+    if (grep("action-button", tag$attribs$class)) {
+      stop("tag is already an action button")
+    }
+  }
+  if (is.null(inputId) && is.null(tag$attribs$id)) {
+    stop("tag does not have any id. Please use inputId to be able to
+           access it on the server side.")
+  }
+  
+  # handle id
+  if (!is.null(inputId)) {
+    if (!is.null(tag$attribs$id)) {
+      cat_red_bullet(
+        paste(
+          "tag already has an id. Please use input$", tag$attribs$id, "to access it from the server side. inputId will be ignored.")
+      )
+    } else {
+      tag$attribs$id <- inputId
+      cat_green_tick("Adding id attribute ...")
+    }
+  } else {
+    cat_green_tick("Using the internal tag id. Nothing to do on your side.")
+  }
+  
+  # handle class
+  if (is.null(tag$attribs$class)) {
+    tag$attribs$class <- "action-button"
+    cat_green_tick("Adding action-button class ...")
+  } else {
+    tag$attribs$class <- paste(tag$attribs$class, "action-button") 
+  }
+  
+  cat_green_tick("Ready to go ...")
+  # return tag
   tag
 }
 

--- a/man/golem.Rd
+++ b/man/golem.Rd
@@ -17,11 +17,11 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Vincent Guyader \email{vincent@thinkr.fr} (\href{https://orcid.org/0000-0003-0671-9270}{ORCID})
+\strong{Maintainer}: Colin Fay \email{contact@colinfay.me} (\href{https://orcid.org/0000-0001-7343-1846}{ORCID})
 
 Authors:
 \itemize{
-  \item Colin Fay \email{contact@colinfay.me} (\href{https://orcid.org/0000-0001-7343-1846}{ORCID})
+  \item Vincent Guyader \email{vincent@thinkr.fr} (\href{https://orcid.org/0000-0003-0671-9270}{ORCID}) (previous maintainer)
   \item Sébastien Rochette \email{sebastien@thinkr.fr} (\href{https://orcid.org/0000-0002-1565-9313}{ORCID})
   \item Cervan Girard \email{cervan@thinkr.fr} (\href{https://orcid.org/0000-0002-4816-4624}{ORCID})
 }


### PR DESCRIPTION
- Change description:

Transform any tag into an action button. Let me know if you want to add more security and restrict the tag type like:

```r
make_action_button <- function(tag, inputId) {
  if (!(tag$name %in% c("a", "button", "..."))) stop("Wrong tag type")
  ...
}
```

- If ever you have some errors, please specify it in your commit message / PR comment:

Below is what I got after forking the repository and before my changes.

```r
[ OK: 114 | SKIPPED: 0 | WARNINGS: 0 | FAILED: 1 ]
1. Error: test use_favicon online (@test-favicon.R#24) 

Error: testthat unit tests failed
In addition: Warning message:
package 'withr' was built under R version 3.6.2 
Execution halted

1 error x | 0 warnings ✓ | 2 notes x
```