### PR TITLE
More precision with the "You choose a png favicon ... etc" message

### DIFF
--- a/R/use_favicon.R
+++ b/R/use_favicon.R
@@ -97,7 +97,7 @@ use_favicon <- function(
   
   if (ext == "png"){
     cat_red_bullet(
-      "You choose a png favicon, please add `ext = 'png'` to the `favicon()` function in golem_add_external_resources()."
+      "You choose a png favicon, please add `ext = 'png'` to `favicon()` within the `golem_add_external_resources()` function in 'app_ui.R'."
     )
   } else {
     cat_line(


### PR DESCRIPTION
Hi, great package thanks. 

I've used an external png file for the favicon (see `use_favicon()`). The initial message was: `* You choose a png favicon, please add `ext = 'png'` to the `favicon()` function in golem_add_external_resources().` however I had to search manually (CTRL SHIFT F) to find where the `golem_add_external_resources()` was located. I think it would be better to add the location of the `golem_add_external_resources()` function within the message. 

Cheers. 

Best regards.