### PR TITLE
set ncpus = 4 as default for package installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rocker/r-ver:3.5.1
-RUN echo "options(repos = c(CRAN = 'https://cran.rstudio.com/'), download.file.method = 'libcurl')" >> /usr/local/lib/R/etc/Rprofile.site
+RUN echo "options(repos = c(CRAN = 'https://cran.rstudio.com/'), download.file.method = 'libcurl', Ncpus = 4)" >> /usr/local/lib/R/etc/Rprofile.site
 RUN R -e 'install.packages("remotes")'
 RUN R -e 'remotes::install_github("r-lib/remotes", ref = "97bbf81")'
 RUN Rscript -e 'remotes::install_version("attempt", version = "0.3.0")'

--- a/tests/testthat/test-add_deploy_helpers.R
+++ b/tests/testthat/test-add_deploy_helpers.R
@@ -99,7 +99,7 @@ test_that("add_dockerfiles multi repos", {
           expect_true(test)
           
           
-    to_find <-   "RUN echo \"options(repos = c(bioc1 = 'https://bioconductor.org/packages/3.10/data/annotation', bioc2 = 'https://bioconductor.org/packages/3.10/data/experiment', CRAN = 'https://cran.rstudio.com'), download.file.method = 'libcurl')\" >> /usr/local/lib/R/etc/Rprofile.site"
+    to_find <-   "RUN echo \"options(repos = c(bioc1 = 'https://bioconductor.org/packages/3.10/data/annotation', bioc2 = 'https://bioconductor.org/packages/3.10/data/experiment', CRAN = 'https://cran.rstudio.com'), download.file.method = 'libcurl', Ncpus = 4)\" >> /usr/local/lib/R/etc/Rprofile.site"
           
           
           


### PR DESCRIPTION
The PR changes tackle issue [Default options(NCpus) to 4 in Dockerfile #406](https://github.com/ThinkR-open/golem/issues/406) and set the default CPUs used for package installation in the Dockerfile to 4 CPUs. This should do the trick.