### PR TITLE
Issue #100 : conditioning the yes no for interactivity

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -47,12 +47,9 @@ get_current_config <- function(
   }
   
   if (!file_exists(path_conf)){
-    ask <- yesno(
-      sprintf(
-        "The %s file doesn't exist, create?", 
-        basename(path_conf)
-      )
-    )
+    ask <- yesno(sprintf(
+      "The %s file doesn't exist, create?", basename(path_conf)
+    ))
     # Return early if the user doesn't allow 
     if (!ask) return(NULL)
     

--- a/R/create_golem.R
+++ b/R/create_golem.R
@@ -42,9 +42,7 @@ create_golem <- function(
   }
   
   if (dir_exists(path)){
-    res <- yesno(
-      paste("The path", path, "already exists, override?")
-    )
+    res <- yesno(paste("The path", path, "already exists, override?"))
     if (!res){
       return(invisible(NULL))
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -36,13 +36,11 @@ create_if_needed <- function(
   # If it doesn't exist, ask if we are allowed 
   # to create it
   if (dont_exist){
-    ask <- yesno(
-      sprintf(
-        "The %s %s doesn't exist, create?", 
-        basename(path), 
-        type
-      )
-    )
+    ask <- yesno(sprintf(
+      "The %s %s doesn't exist, create?", 
+      basename(path), 
+      type
+    ))
     # Return early if the user doesn't allow 
     if (!ask) {
       return(FALSE)

--- a/R/yesno.R
+++ b/R/yesno.R
@@ -1,6 +1,12 @@
+# @param ... Arguments passed to the `cat` function.
+# @param default Boolean default value to return in case there is no user
+#      interaction.
+#
 #' @importFrom utils menu
-yesno <- function (...) 
-{
+yesno <- function(..., default = FALSE) {
+  if (!interactive()) {
+    return(default)
+  }
   cat(paste0(..., collapse = ""))
   menu(c("Yes", "No")) == 1
 }


### PR DESCRIPTION
As requested in #100 , I added a default value for the `yesno` function in case R is not running `interactive()`.
The `yesno` function is being used in five places. So far, I think that, for these calls, the default value as `FALSE` works as it should. Please let me know if it should be changed in any of these 5 places.

For instance, if the session is not interactive, and a folder or file should be overwritten, the default action is not to overwrite.

Note: Currently the project is failing when `devtools::check()`.