### PR TITLE
Remove _ui from modules names fixes issue #651

### DIFF
--- a/R/add_modules.R
+++ b/R/add_modules.R
@@ -187,10 +187,10 @@ module_template <- function(
     write_there("    ")
     
     write_there("## To be copied in the UI")
-    write_there(sprintf('# mod_%s_ui("%s_ui_1")', name, name))
+    write_there(sprintf('# mod_%s_ui("%s_1")', name, name))
     write_there("    ")
     write_there("## To be copied in the server")
-    write_there(sprintf('# callModule(mod_%s_server, "%s_ui_1")', name, name))
+    write_there(sprintf('# callModule(mod_%s_server, "%s_1")', name, name))
     
     
   } else {
@@ -212,10 +212,10 @@ module_template <- function(
     write_there("    ")
     
     write_there("## To be copied in the UI")
-    write_there(sprintf('# mod_%s_ui("%s_ui_1")', name, name))
+    write_there(sprintf('# mod_%s_ui("%s_1")', name, name))
     write_there("    ")
     write_there("## To be copied in the server")
-    write_there(sprintf('# mod_%s_server("%s_ui_1")', name, name))
+    write_there(sprintf('# mod_%s_server("%s_1")', name, name))
     
   }
 }

--- a/inst/manualtests/script.R
+++ b/inst/manualtests/script.R
@@ -66,7 +66,7 @@ ui <- readLines("R/app_ui.R")
 ui <- append(
   ui,
   c(
-    ',mod_my_first_module_ui("my_first_module_ui_1")'
+    ',mod_my_first_module_ui("my_first_module_1")'
   ), 
   grep(
     "h1", 
@@ -79,7 +79,7 @@ server <- readLines("R/app_server.R")
 server <- append(
   server,
   c(
-    'callModule(mod_my_first_module_server, "my_first_module_ui_1")'
+    'callModule(mod_my_first_module_server, "my_first_module_1")'
   ), 
   grep(
     "first level callModules", 


### PR DESCRIPTION
My dear Mr. Fay,

Please find my first contribution to your great package.

Modules will now be named according to the scheme `mod_pouet_1`, and not `mod_pouet_ui_1,` where `pouet` refers to the string passed to the `name` argument of the `add_module()` function.

By the way, I wonder if the `_1` is still relevant here. If not, please let me know so I can remove it too.

Kind regards, 

Margot 

Fixes issue #651