### PR TITLE
Use JS to resize cached plots

### DIFF
--- a/inst/utils/golem-js.js
+++ b/inst/utils/golem-js.js
@@ -59,6 +59,14 @@ $( document ).ready(function() {
     return input;
   });
   
+  Shiny.addCustomMessageHandler('tosize', function(args) {
+    document.getElementById(args.id).setAttribute("style","height:" + args.size + ";width:100%");
+  });
+
+  Shiny.addCustomMessageHandler ('resize',function (message) {
+    $(window).trigger('resize');
+  });
+  
 });
 
 


### PR DESCRIPTION
- tosize allows to change style of a specific div
- resize resises the windows to allow shiny take into account new div sizes

Use for instance as follows: 
 ```r
observeEvent(input$graph_size, {
      session$sendCustomMessage("tosize", list(id = glue::glue("{ns('plot')}"), size = input$graph_size))
      session$sendCustomMessage("resize", glue::glue("resize {ns('plot')}"))
})
```