### PR TITLE
use yesno() only in interactive mode

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -47,37 +47,47 @@ get_current_config <- function(
   }
   
   if (!file_exists(path_conf)){
-    ask <- yesno(
-      sprintf(
-        "The %s file doesn't exist, create?", 
-        basename(path_conf)
+    if (interactive()) {
+      ask <- yesno(
+        sprintf(
+          "The %s file doesn't exist, create?", 
+          basename(path_conf)
+        )
       )
-    )
-    # Return early if the user doesn't allow 
-    if (!ask) return(NULL)
-    
-    file_copy(
-      path = golem_sys("shinyexample/inst/golem-config.yml"), 
-      new_path = path(
-        path, "inst/golem-config.yml"
+      # Return early if the user doesn't allow 
+      if (!ask) return(NULL)
+      
+      file_copy(
+        path = golem_sys("shinyexample/inst/golem-config.yml"), 
+        new_path = path(
+          path, "inst/golem-config.yml"
+        )
       )
-    )
-    file_copy(
-      path = golem_sys("shinyexample/R/app_config.R"), 
-      new_path = file.path(
-        path, "R/app_config.R"
+      file_copy(
+        path = golem_sys("shinyexample/R/app_config.R"), 
+        new_path = file.path(
+          path, "R/app_config.R"
+        )
       )
-    )
-    replace_word(
-      path(
-        path, "R/app_config.R"
-      ), 
-      "shinyexample", 
-      pkg_name()
-    )
-    if (set_options){
-      set_golem_options()
+      replace_word(
+        path(
+          path, "R/app_config.R"
+        ), 
+        "shinyexample", 
+        pkg_name()
+      )
+      if (set_options){
+        set_golem_options()
+      }
+    } else {
+      stop(
+        sprintf(
+          "The %s file doesn't exist.", 
+          basename(path_conf)
+        )
+      )
     }
+
   }
   
   return(

--- a/R/create_golem.R
+++ b/R/create_golem.R
@@ -54,11 +54,15 @@ create_golem <- function(
   }
   
   if (dir_exists(path)){
-    res <- yesno(
-      paste("The path", path, "already exists, override?")
-    )
-    if (!res){
-      return(invisible(NULL))
+    if (interactive()) {
+      res <- yesno(
+        paste("The path", path, "already exists, override?")
+      )
+      if (!res){
+        return(invisible(NULL))
+      }
+    } else {
+      stop(paste("The path", path, "already exists."))
     }
   }
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -36,24 +36,34 @@ create_if_needed <- function(
   # If it doesn't exist, ask if we are allowed 
   # to create it
   if (dont_exist){
-    ask <- yesno(
-      sprintf(
-        "The %s %s doesn't exist, create?", 
-        basename(path), 
-        type
+    if (interactive()) {
+      ask <- yesno(
+        sprintf(
+          "The %s %s doesn't exist, create?", 
+          basename(path), 
+          type
+        )
       )
-    )
-    # Return early if the user doesn't allow 
-    if (!ask) {
-      return(FALSE)
-    } else {
-      # Create the file 
-      if (type == "file"){
-        file_create(path)
-        write(content, path, append = TRUE)
-      } else if (type == "directory"){
-        dir_create(path, recurse = TRUE)
+      # Return early if the user doesn't allow 
+      if (!ask) {
+        return(FALSE)
+      } else {
+        # Create the file 
+        if (type == "file"){
+          file_create(path)
+          write(content, path, append = TRUE)
+        } else if (type == "directory"){
+          dir_create(path, recurse = TRUE)
+        }
       }
+    } else {
+      stop(
+        sprintf(
+          "The %s %s doesn't exist.", 
+          basename(path), 
+          type
+        )
+      )
     }
   } 
   
@@ -66,7 +76,11 @@ create_if_needed <- function(
 check_file_exist <- function(file){
   res <- TRUE
   if (file_exists(file)){
-    res <- yesno("This file already exists, override?")
+    if (interactive()) {
+      res <- yesno("This file already exists, override?")
+    } else {
+      res <- TRUE
+    }
   }
   return(res)
 }
@@ -76,7 +90,11 @@ check_file_exist <- function(file){
 check_dir_exist <- function(dir){
   res <- TRUE
   if (!dir_exists(dir)){ 
-    res <- yesno(sprintf("The %s does not exists, create?", dir))
+    if (interactive()) {
+      res <- yesno(sprintf("The %s does not exists, create?", dir))
+    } else {
+      res <- FALSE
+    }
   }
   return(res)
 }


### PR DESCRIPTION
Hi, this is a PR related to #100.

Now, in terminal, an error is displayed when path already exists:
```bash
etienne@etienne-laptop$ Rscript -e "golem::create_golem('plop')"
── Checking package name ──────────────────────────────────────────────────────────────────
✓ Valid package name
Erreur dans golem::create_golem("plop") : The path plop already exists.
Exécution arrêtée
```
If not in an interactive mode, the code stops by default instead of creating/overwriting files or folders. 

Note that I'm just a little surprised by the code of `check_file_exist()` (in `utils.R`). I was expecting a code very similar to `check_dir_exist()`, but the behavior is quite different:

* in `check_dir_exist()`, if dir doesn't exist, the user is asked whether they want to create it
* in `check_file_exist()`, if file already exists, the user is asked whether they want to override it, which seems strange for a function whose purpose is to check if a file exists.

I didn't want to spend too much time on that, just wondering if this is done on purpose.