### PR TITLE
Replace calls to testhat::expect_is()

### DIFF
--- a/tests/testthat/test-favicon.R
+++ b/tests/testthat/test-favicon.R
@@ -32,7 +32,7 @@ test_that("test use_favicon online fail",{
     golem::remove_favicon()
     expect_false(file.exists("inst/app/www/favicon.ico"))
     if (getRversion() >= "3.5"){
-    expect_error(use_favicon(path = "https://fr.wikipedia.org//static/favicon/dontexist.ico"))
+      expect_error(use_favicon(path = "https://fr.wikipedia.org//static/favicon/dontexist.ico"))
     }
     expect_false(file.exists("inst/app/www/favicon.ico"))
   })
@@ -40,10 +40,9 @@ test_that("test use_favicon online fail",{
 
 test_that("test favicon",{
   with_dir(pkg,{
-    expect_is(
+    expect_s3_class(
       favicon("jean","jean"),
       "shiny.tag"
     )
   })
 })
-

--- a/tests/testthat/test-js.R
+++ b/tests/testthat/test-js.R
@@ -1,5 +1,5 @@
 test_that("active_js", {
-  expect_is(activate_js(),'shiny.tag')
+  expect_s3_class(activate_js(), "shiny.tag")
 })
 
 

--- a/tests/testthat/test-make_dev.R
+++ b/tests/testthat/test-make_dev.R
@@ -3,16 +3,16 @@ test_that("test app_dev",{
     c(
       golem.app.prod = TRUE
     ),{
-    expect_false(app_dev()) 
-    expect_true(app_prod()) 
-  })
+      expect_false(app_dev())
+      expect_true(app_prod())
+    })
   with_options(
     c(
       golem.app.prod = FALSE
     ),{
-    expect_true(app_dev()) 
-    expect_false(app_prod()) 
-  })
+      expect_true(app_dev())
+      expect_false(app_prod())
+    })
 })
 
 test_that("test print_dev",{
@@ -20,9 +20,9 @@ test_that("test print_dev",{
     c(
       golem.app.prod = FALSE
     ),{
-    expect_equal(print_dev("test"),"test")
-    expect_is(print_dev("test"), "character")
-  })
+      expect_equal(print_dev("test"),"test")
+      expect_type(print_dev("test"), "character")
+    })
 })
 
 test_that("test make_dev",{
@@ -30,12 +30,12 @@ test_that("test make_dev",{
     c(
       golem.app.prod = FALSE
     ),{
-    sum_dev <- make_dev(sum)
-    class(sum_dev)
-    expect_equal(sum_dev(1,2),3)
-    expect_is(sum_dev(1,2), "numeric")
-    expect_is(sum_dev, "function")
-  })
+      sum_dev <- make_dev(sum)
+      class(sum_dev)
+      expect_equal(sum_dev(1,2),3)
+      expect_type(sum_dev(1,2), "double")
+      expect_type(sum_dev, "closure")
+    })
 })
 
 test_that("test print_dev",{
@@ -43,30 +43,30 @@ test_that("test print_dev",{
     c(
       golem.app.prod = FALSE
     ),{
-    expect_equal(print_dev("test"),"test")
-    expect_is(print_dev("test"), "character")
-  })
+      expect_equal(print_dev("test"),"test")
+      expect_type(print_dev("test"), "character")
+    })
 })
 
 
 test_that("test browser_button",{
- 
-    output <- capture_output_lines(browser_button())
-    expect_true(
-      grepl('actionButton\\("browser", "browser"\\)', output[2])
-    )
-    expect_true(
-      grepl('tags\\$script\\(\"\\$\\(\'#browser\'\\).hide\\(\\);\"\\)', output[3])
-    )
-    expect_true(
-      grepl('observeEvent\\(input\\$browser', output[6])
-    )
-    expect_true(
-      grepl('  browser()', output[7])
-    )
-    expect_true(
-      grepl('run \\$\\(\'#browser\'\\)\\.show\\(\\);', output[12])
-    )
+  
+  output <- capture_output_lines(browser_button())
+  expect_true(
+    grepl('actionButton\\("browser", "browser"\\)', output[2])
+  )
+  expect_true(
+    grepl('tags\\$script\\(\"\\$\\(\'#browser\'\\).hide\\(\\);\"\\)', output[3])
+  )
+  expect_true(
+    grepl('observeEvent\\(input\\$browser', output[6])
+  )
+  expect_true(
+    grepl('  browser()', output[7])
+  )
+  expect_true(
+    grepl('run \\$\\(\'#browser\'\\)\\.show\\(\\);', output[12])
+  )
 })
 
 # test_that("test set_option",{


### PR DESCRIPTION
Replace calls to testhat::expect_is() by up-to-date alternatives: expect_type() or expect_s3_class().
Note that one test regarding line endings will not suceed. cf #744.