### PR TITLE
735 check module exists before adding new related files

### DIFF
--- a/R/add_r_files.R
+++ b/R/add_r_files.R
@@ -21,9 +21,17 @@ add_r_files <- function(
     cat_dir_necessary()
     return(invisible(FALSE))
   }
+  
   if (!is.null(module)){
+    if (!is_existing_module(module)) {
+      stop(
+        "The mentionned 'module' does not yet exist.",
+        call. = FALSE
+      )
+    } 
     module <- paste0("mod_", module, "_")
   }
+  
   where <- path(
     "R", paste0(module, ext, "_", name, ".R")
   )

--- a/R/add_r_files.R
+++ b/R/add_r_files.R
@@ -1,159 +1,153 @@
 #' @importFrom fs path_abs path file_create
-add_r_files <- function(
-  name, 
-  ext = c("fct", "utils"),
-  module = "",
-  pkg = get_golem_wd(), 
-  open = TRUE, 
-  dir_create = TRUE
-){
-  
+add_r_files <- function(name,
+                        ext = c("fct", "utils"),
+                        module = "",
+                        pkg = get_golem_wd(),
+                        open = TRUE,
+                        dir_create = TRUE) {
   name <- file_path_sans_ext(name)
-  
+
   old <- setwd(path_abs(pkg))
   on.exit(setwd(old))
-  
+
   dir_created <- create_if_needed(
-    "R", type = "directory"
+    "R",
+    type = "directory"
   )
-  
-  if (!dir_created){
+
+  if (!dir_created) {
     cat_dir_necessary()
     return(invisible(FALSE))
   }
-  
-  if (!is.null(module)){
+
+  if (!is.null(module)) {
     # Remove the extension if any
     module <- file_path_sans_ext(module)
     # Remove the "mod_" if any
     module <- mod_remove(module)
     if (!is_existing_module(module)) {
       stop(
-        "The mentionned 'module' does not yet exist.",
+        sprintf(
+          "The module '%s' does not exist.\nYou can call `golem::add_module('%s')` to create it.", 
+          module, 
+          module
+          ),
         call. = FALSE
       )
-    } 
+    }
     module <- paste0("mod_", module, "_")
   }
-  
+
   where <- path(
     "R", paste0(module, ext, "_", name, ".R")
   )
-  
-  if (!file_exists(where)){
+
+  if (!file_exists(where)) {
     file_create(where)
-    
-    if(file_exists(where) & is.null(module)) {
+
+    if (file_exists(where) & is.null(module)) {
       # Must be a function or utility file being created
       append_roxygen_comment(
-        name = name, 
-        path = where, 
+        name = name,
+        path = where,
         ext = ext
-        )
+      )
     }
-    
+
     cat_created(where)
   } else {
     file_already_there_dance(
-      where = where, 
+      where = where,
       open_file = open
     )
   }
-  
+
   open_or_go_to(where, open)
-  
 }
 
 #' Add fct_ and utils_ files
-#' 
-#' These functions add files in the R/ folder 
-#' that starts either with `fct_` (short for function) 
+#'
+#' These functions add files in the R/ folder
+#' that starts either with `fct_` (short for function)
 #' or with `utils_`.
 #'
 #' @param name The name of the file
-#' @param module If not NULL, the file will be module specific 
+#' @param module If not NULL, the file will be module specific
 #'     in the naming (you don't need to add the leading `mod_`).
 #' @inheritParams  add_module
-#' 
+#'
 #' @rdname file_creation
 #' @export
-#' 
+#'
 #' @return The path to the file, invisibly.
-add_fct <- function(
-  name, 
-  module = NULL,
-  pkg = get_golem_wd(), 
-  open = TRUE, 
-  dir_create = TRUE
-){
+add_fct <- function(name,
+                    module = NULL,
+                    pkg = get_golem_wd(),
+                    open = TRUE,
+                    dir_create = TRUE) {
   add_r_files(
-    name, 
+    name,
     module,
     ext = "fct",
-    pkg = pkg, 
-    open = open, 
+    pkg = pkg,
+    open = open,
     dir_create = dir_create
   )
 }
 
 #' @rdname file_creation
 #' @export
-add_utils <- function(
-  name, 
-  module = NULL,
-  pkg = get_golem_wd(), 
-  open = TRUE, 
-  dir_create = TRUE
-){
+add_utils <- function(name,
+                      module = NULL,
+                      pkg = get_golem_wd(),
+                      open = TRUE,
+                      dir_create = TRUE) {
   add_r_files(
-    name, 
+    name,
     module,
     ext = "utils",
-    pkg = pkg, 
-    open = open, 
+    pkg = pkg,
+    open = open,
     dir_create = dir_create
   )
 }
 
 #' Append roxygen comments to `fct_` and `utils_` files
-#' 
-#' This function add boilerplate roxygen comments 
+#'
+#' This function add boilerplate roxygen comments
 #' for fct_ and utils_ files.
 #'
 #' @param name The name of the file
-#' @param path The path to the R script where the module will be written. 
-#' @param ext A string denoting the type of file to be created. 
-#' 
+#' @param path The path to the R script where the module will be written.
+#' @param ext A string denoting the type of file to be created.
+#'
 #' @rdname file_creation
 #' @noRd
-append_roxygen_comment <- function(
-  name,
-  path, 
-  ext, 
-  export = FALSE
-) {
-  write_there <- function(...){
+append_roxygen_comment <- function(name,
+                                   path,
+                                   ext,
+                                   export = FALSE) {
+  write_there <- function(...) {
     write(..., file = path, append = TRUE)
   }
-  
-  file_type = " "
-  
-  if(ext == "utils") {
-    file_type = "utility"
+
+  file_type <- " "
+
+  if (ext == "utils") {
+    file_type <- "utility"
   } else {
-    file_type = "function"
+    file_type <- "function"
   }
-  
+
   write_there(sprintf("#' %s ", name))
   write_there("#'")
   write_there(sprintf("#' @description A %s function", ext))
   write_there("#'")
   write_there(sprintf("#' @return The return value, if any, from executing the %s.", file_type))
   write_there("#'")
-  if (export){
+  if (export) {
     write_there("#' @export")
   } else {
     write_there("#' @noRd")
   }
-  
 }

--- a/R/add_r_files.R
+++ b/R/add_r_files.R
@@ -23,6 +23,10 @@ add_r_files <- function(
   }
   
   if (!is.null(module)){
+    # Remove the extension if any
+    module <- file_path_sans_ext(module)
+    # Remove the "mod_" if any
+    module <- mod_remove(module)
     if (!is_existing_module(module)) {
       stop(
         "The mentionned 'module' does not yet exist.",

--- a/R/modules_fn.R
+++ b/R/modules_fn.R
@@ -52,7 +52,7 @@ add_module <- function(name,
     cat_dir_necessary()
     return(invisible(FALSE))
   }
-  
+
   where <- path(
     "R", paste0("mod_", name, ".R")
   )
@@ -71,23 +71,23 @@ add_module <- function(name,
       open_file = open
     )
   }
-  
+
   if (!is.null(fct)) {
     add_fct(fct, module = name, open = open)
   }
-  
+
   if (!is.null(utils)) {
     add_utils(utils, module = name, open = open)
   }
-  
+
   if (!is.null(js)) {
     add_js_file(js, pkg = pkg, open = open)
   }
-  
+
   if (!is.null(js_handler)) {
     add_js_handler(js_handler, pkg = pkg, open = open)
   }
-  
+
   if (with_test) {
     use_module_test(
       name = name,
@@ -231,19 +231,23 @@ module_template <- function(name,
 use_module_test <- function(name,
                             pkg = get_golem_wd(),
                             open = TRUE) {
-  
+
   # Remove the extension if any
   name <- file_path_sans_ext(name)
   # Remove the "mod_" if any
   name <- mod_remove(name)
-  
+
   if (!is_existing_module(name)) {
     stop(
-      "The mentionned 'module' does not yet exist.",
+      sprintf(
+        "The module '%s' does not exist.\nYou can call `golem::add_module('%s')` to create it.",
+        name,
+        name
+      ),
       call. = FALSE
     )
   }
-  
+
   # We need both testthat, usethis & fs
   check_is_installed("testthat")
   check_is_installed("usethis")
@@ -251,7 +255,7 @@ use_module_test <- function(name,
 
   old <- setwd(fs::path_abs(pkg))
   on.exit(setwd(old))
-  
+
   uses_testthat <- getFromNamespace(
     "uses_testthat",
     "usethis"

--- a/R/modules_fn.R
+++ b/R/modules_fn.R
@@ -231,7 +231,19 @@ module_template <- function(name,
 use_module_test <- function(name,
                             pkg = get_golem_wd(),
                             open = TRUE) {
-
+  
+  # Remove the extension if any
+  name <- file_path_sans_ext(name)
+  # Remove the "mod_" if any
+  name <- mod_remove(name)
+  
+  if (!is_existing_module(name)) {
+    stop(
+      "The mentionned 'module' does not yet exist.",
+      call. = FALSE
+    )
+  }
+  
   # We need both testthat, usethis & fs
   check_is_installed("testthat")
   check_is_installed("usethis")
@@ -239,12 +251,7 @@ use_module_test <- function(name,
 
   old <- setwd(fs::path_abs(pkg))
   on.exit(setwd(old))
-
-  # Remove the extension if any
-  name <- file_path_sans_ext(name)
-  # Remove the "mod_" if any
-  name <- mod_remove(name)
-
+  
   uses_testthat <- getFromNamespace(
     "uses_testthat",
     "usethis"

--- a/R/modules_fn.R
+++ b/R/modules_fn.R
@@ -52,23 +52,7 @@ add_module <- function(name,
     cat_dir_necessary()
     return(invisible(FALSE))
   }
-
-  if (!is.null(fct)) {
-    add_fct(fct, module = name, open = open)
-  }
-
-  if (!is.null(utils)) {
-    add_utils(utils, module = name, open = open)
-  }
-
-  if (!is.null(js)) {
-    add_js_file(js, pkg = pkg, open = open)
-  }
-
-  if (!is.null(js_handler)) {
-    add_js_handler(js_handler, pkg = pkg, open = open)
-  }
-
+  
   where <- path(
     "R", paste0("mod_", name, ".R")
   )
@@ -87,7 +71,23 @@ add_module <- function(name,
       open_file = open
     )
   }
-
+  
+  if (!is.null(fct)) {
+    add_fct(fct, module = name, open = open)
+  }
+  
+  if (!is.null(utils)) {
+    add_utils(utils, module = name, open = open)
+  }
+  
+  if (!is.null(js)) {
+    add_js_file(js, pkg = pkg, open = open)
+  }
+  
+  if (!is.null(js_handler)) {
+    add_js_handler(js_handler, pkg = pkg, open = open)
+  }
+  
   if (with_test) {
     use_module_test(
       name = name,

--- a/R/utils.R
+++ b/R/utils.R
@@ -467,3 +467,20 @@ add_sass_code <- function(where, dir, name) {
     }
   }
 }
+
+
+#' Check if a module already exists
+#' 
+#' Assumes it is called at the root of a golem project.
+#' 
+#' @param module A character string. The name of a potentially existing module
+#' @return Boolean. Does the module exist or not ?
+#' @noRd
+is_existing_module <- function(module) {
+  existing_module_files <- list.files("R/", pattern = "^mod_")
+  existing_module_names <- sub(
+    "^mod_([[:alnum:]_]+)\\.R$", "\\1", 
+    existing_module_files
+  )
+  module %in% existing_module_names
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -468,7 +468,6 @@ add_sass_code <- function(where, dir, name) {
   }
 }
 
-
 #' Check if a module already exists
 #' 
 #' Assumes it is called at the root of a golem project.

--- a/tests/testthat/helper-config.R
+++ b/tests/testthat/helper-config.R
@@ -2,47 +2,47 @@
 library(golem)
 library(withr)
 ### Funs
-remove_file <- function(path){
+remove_file <- function(path) {
   if (file.exists(path)) unlink(path, force = TRUE)
 }
 
-remove_files <- function(path, pattern = NULL){
+remove_files <- function(path, pattern = NULL) {
   fls <- list.files(
-    path, pattern, full.names = TRUE, recursive = TRUE
+    path, pattern,
+    full.names = TRUE, recursive = TRUE
   )
-  if (length(fls) >0){
-    res <- lapply(fls, function(x){
+  if (length(fls) > 0) {
+    res <- lapply(fls, function(x) {
       if (file.exists(x)) unlink(x, force = TRUE)
     })
   }
 }
 
 expect_exists <- function(fls) {
-  
   act <- list(
-    val = fls, 
+    val = fls,
     lab = fls
   )
-  
+
   act$val <- file.exists(fls)
   expect(
     isTRUE(act$val),
     sprintf("File %s doesn't exist.", fls)
   )
-  
+
   invisible(act$val)
 }
 
-burn_after_reading <- function(file, exp){
+burn_after_reading <- function(file, exp) {
   unlink(file, force = TRUE)
   force(exp)
   unlink(file, force = TRUE)
 }
 
-# We prevent the random name from having 
-# ui or server inside it 
-safe_let <- function(){
-  letters[-c(5,9,18,19,21,22)]
+# We prevent the random name from having
+# ui or server inside it
+safe_let <- function() {
+  letters[-c(5, 9, 18, 19, 21, 22)]
 }
 
 ## fake package
@@ -53,7 +53,7 @@ fakename <- sprintf(
 )
 
 tpdir <- normalizePath(tempdir())
-unlink(file.path(tpdir,fakename), recursive = TRUE)
+unlink(file.path(tpdir, fakename), recursive = TRUE)
 create_golem(file.path(tpdir, fakename), open = FALSE)
 pkg <- file.path(tpdir, fakename)
 
@@ -62,7 +62,7 @@ randir <- paste0(sample(safe_let(), 10, TRUE), collapse = "")
 fp <- file.path("inst/app", randir)
 dir.create(file.path(pkg, fp), recursive = TRUE)
 
-rand_name <- function(){
+rand_name <- function() {
   paste0(sample(safe_let(), 10, TRUE), collapse = "")
 }
 
@@ -72,4 +72,3 @@ withr::with_dir(pkg, {
   orig_test <- set_golem_wd(pkg)
   usethis::use_mit_license("Golem")
 })
-

--- a/tests/testthat/test-add_r_files.R
+++ b/tests/testthat/test-add_r_files.R
@@ -28,6 +28,20 @@ test_that("add_fct and add_utils", {
       regexp = "^The mentionned 'module' does not yet exist.$"
     )
     
+    # Module file passed instead of name
+    mod_ploup_file <- "R/mod_ploup.R"
+    remove_file(mod_ploup_file)
+    add_module("ploup", pkg = pkg, open = FALSE)
+    add_fct("fct", module = basename(mod_ploup_file), pkg = pkg, open = FALSE)
+    add_utils("utils", module = basename(mod_ploup_file), pkg = pkg, open = FALSE)
+    expect_true(file.exists("R/mod_ploup_fct_fct.R"))
+    expect_true(file.exists("R/mod_ploup_utils_utils.R"))
+    
+    
+    remove_file(mod_ploup_file)
+    remove_file("R/mod_ploup_fct_fct.R")
+    remove_file("R/mod_ploup_utils_utils.R")
+    
     remove_file(sprintf("R/mod_%s.R", rand))
     remove_file(sprintf("R/mod_%s_fct_ui.R", rand))
     remove_file(sprintf("R/mod_%s_utils_ui.R", rand))

--- a/tests/testthat/test-add_r_files.R
+++ b/tests/testthat/test-add_r_files.R
@@ -18,6 +18,16 @@ test_that("add_fct and add_utils", {
     expect_true(file.exists(sprintf("R/mod_%s_fct_ui.R", rand)))    
     expect_true(file.exists(sprintf("R/mod_%s_utils_ui.R", rand)))    
     
+    # If module not yet created an error is thrown
+    expect_error(
+      add_fct("ui", module = "notyetcreated", pkg = pkg, open = FALSE),
+      regexp = "^The mentionned 'module' does not yet exist.$"
+    )
+    expect_error(
+      add_utils("ui", module = "notyetcreated", pkg = pkg, open = FALSE),
+      regexp = "^The mentionned 'module' does not yet exist.$"
+    )
+    
     remove_file(sprintf("R/mod_%s.R", rand))
     remove_file(sprintf("R/mod_%s_fct_ui.R", rand))
     remove_file(sprintf("R/mod_%s_utils_ui.R", rand))

--- a/tests/testthat/test-add_r_files.R
+++ b/tests/testthat/test-add_r_files.R
@@ -8,26 +8,26 @@ test_that("add_fct and add_utils", {
     remove_file(mod)
     add_fct("ui", pkg = pkg, open = FALSE)
     add_utils("ui", pkg = pkg, open = FALSE)
-    
-    expect_true(file.exists(util_file))    
-    expect_true(file.exists(fct_file))    
+
+    expect_true(file.exists(util_file))
+    expect_true(file.exists(fct_file))
     rand <- rand_name()
     add_module(rand, pkg = pkg, open = FALSE)
     add_fct("ui", rand, pkg = pkg, open = FALSE)
     add_utils("ui", rand, pkg = pkg, open = FALSE)
-    expect_true(file.exists(sprintf("R/mod_%s_fct_ui.R", rand)))    
-    expect_true(file.exists(sprintf("R/mod_%s_utils_ui.R", rand)))    
-    
+    expect_true(file.exists(sprintf("R/mod_%s_fct_ui.R", rand)))
+    expect_true(file.exists(sprintf("R/mod_%s_utils_ui.R", rand)))
+
     # If module not yet created an error is thrown
     expect_error(
       add_fct("ui", module = "notyetcreated", pkg = pkg, open = FALSE),
-      regexp = "^The mentionned 'module' does not yet exist.$"
+      regexp = "The module 'notyetcreated' does not exist."
     )
     expect_error(
       add_utils("ui", module = "notyetcreated", pkg = pkg, open = FALSE),
-      regexp = "^The mentionned 'module' does not yet exist.$"
+      regexp = "The module 'notyetcreated' does not exist."
     )
-    
+
     # Module file passed instead of name
     mod_ploup_file <- "R/mod_ploup.R"
     remove_file(mod_ploup_file)
@@ -36,12 +36,12 @@ test_that("add_fct and add_utils", {
     add_utils("utils", module = basename(mod_ploup_file), pkg = pkg, open = FALSE)
     expect_true(file.exists("R/mod_ploup_fct_fct.R"))
     expect_true(file.exists("R/mod_ploup_utils_utils.R"))
-    
-    
+
+
     remove_file(mod_ploup_file)
     remove_file("R/mod_ploup_fct_fct.R")
     remove_file("R/mod_ploup_utils_utils.R")
-    
+
     remove_file(sprintf("R/mod_%s.R", rand))
     remove_file(sprintf("R/mod_%s_fct_ui.R", rand))
     remove_file(sprintf("R/mod_%s_utils_ui.R", rand))

--- a/tests/testthat/test-modules_fn.R
+++ b/tests/testthat/test-modules_fn.R
@@ -3,26 +3,25 @@ test_that("use_module_test", {
   with_dir(pkg, {
     add_module("mod1", open = FALSE, pkg = pkg)
     add_module("mod2", open = FALSE, pkg = pkg)
-    
+
     # Proper module name
     use_module_test("mod1", pkg = pkg, open = FALSE)
     expect_true(file.exists("tests/testthat/test-mod_mod1.R"))
-    
+
     # Non existing module
     expect_error(
       use_module_test("phatom", pkg = pkg, open = FALSE),
-      regex = "^The mentionned 'module' does not yet exist.$"
+      regex = "The module 'phatom' does not exist"
     )
-    
-    # Module file passed instead of name 
+
+    # Module file passed instead of name
     use_module_test("mod_mod2.R", pkg = pkg, open = FALSE)
     expect_true(file.exists("tests/testthat/test-mod_mod2.R"))
-    
+
     lapply(
       list.files(pattern = "(^|^test-)mod_mod\\d.R$", recursive = TRUE),
       remove_file
     )
-    
   })
 })
 

--- a/tests/testthat/test-modules_fn.R
+++ b/tests/testthat/test-modules_fn.R
@@ -1,19 +1,28 @@
 
 test_that("use_module_test", {
   with_dir(pkg, {
-    remove_file("R/mod_mod1.R")
     add_module("mod1", open = FALSE, pkg = pkg)
+    add_module("mod2", open = FALSE, pkg = pkg)
     
+    # Proper module name
     use_module_test("mod1", pkg = pkg, open = FALSE)
     expect_true(file.exists("tests/testthat/test-mod_mod1.R"))
     
+    # Non existing module
     expect_error(
-      use_module_test("mod2", pkg = pkg, open = FALSE),
+      use_module_test("phatom", pkg = pkg, open = FALSE),
       regex = "^The mentionned 'module' does not yet exist.$"
     )
     
-    remove_file("R/mod_mod1.R")
-    remove_file("tests/testthat/test-mod_mod1.R")
+    # Module file passed instead of name 
+    use_module_test("mod_mod2.R", pkg = pkg, open = FALSE)
+    expect_true(file.exists("tests/testthat/test-mod_mod2.R"))
+    
+    lapply(
+      list.files(pattern = "(^|^test-)mod_mod\\d.R$", recursive = TRUE),
+      remove_file
+    )
+    
   })
 })
 

--- a/tests/testthat/test-modules_fn.R
+++ b/tests/testthat/test-modules_fn.R
@@ -1,3 +1,22 @@
+
+test_that("use_module_test", {
+  with_dir(pkg, {
+    remove_file("R/mod_mod1.R")
+    add_module("mod1", open = FALSE, pkg = pkg)
+    
+    use_module_test("mod1", pkg = pkg, open = FALSE)
+    expect_true(file.exists("tests/testthat/test-mod_mod1.R"))
+    
+    expect_error(
+      use_module_test("mod2", pkg = pkg, open = FALSE),
+      regex = "^The mentionned 'module' does not yet exist.$"
+    )
+    
+    remove_file("R/mod_mod1.R")
+    remove_file("tests/testthat/test-mod_mod1.R")
+  })
+})
+
 test_that("module_fn work", {
   expect_equal(
     mod_remove("mod_a"),

--- a/tests/testthat/test-modules_fn.R
+++ b/tests/testthat/test-modules_fn.R
@@ -30,4 +30,8 @@ test_that("module_fn work", {
     mod_remove("a_mod_a"),
     "a_mod_a"
   )
+  expect_equal(
+    mod_remove("mod_mod1"),
+    "mod1"
+  )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,14 @@
+
+dummy_golem <- tempfile(pattern = "test_is_existing_modules")
+dummy_golem_R <- file.path(dummy_golem, "R/")
+dir.create(dummy_golem_R, recursive = TRUE)
+dummy_module_files <- c("mod_main.R", "mod_left_pane.R")
+file.create(file.path(dummy_golem_R, dummy_module_files))
+
+withr::with_dir(dummy_golem, {
+  test_that("existing modules are properly detected", {
+    expect_false(is_existing_module("foo"))
+    expect_true(is_existing_module("left_pane"))
+    expect_true(is_existing_module("main"))
+  })
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -2,7 +2,7 @@
 dummy_golem <- tempfile(pattern = "test_is_existing_modules")
 dummy_golem_R <- file.path(dummy_golem, "R/")
 dir.create(dummy_golem_R, recursive = TRUE)
-dummy_module_files <- c("mod_main.R", "mod_left_pane.R")
+dummy_module_files <- c("mod_main.R", "mod_left_pane.R", "mod_pouet_pouet.R")
 file.create(file.path(dummy_golem_R, dummy_module_files))
 
 withr::with_dir(dummy_golem, {
@@ -10,5 +10,7 @@ withr::with_dir(dummy_golem, {
     expect_false(is_existing_module("foo"))
     expect_true(is_existing_module("left_pane"))
     expect_true(is_existing_module("main"))
+    expect_true(is_existing_module("pouet_pouet"))
+    expect_false(is_existing_module("plif_plif"))
   })
 })


### PR DESCRIPTION
Closes #735 

`add_fct()`, `add_utils()` and `use_module_test()` are now all:

* checking in a uniform way that the designated module already exist and if not throw the same error message.
* tolerating that the user passes the module file name (`mod_something.R`) instead of the module name (`something`).
