### PR TITLE
switched to rlang for checking package installation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,6 +57,7 @@ Imports:
     fs,
     here,
     htmltools,
+    rlang,
     pkgload,
     roxygen2,
     rstudioapi,
@@ -65,7 +66,6 @@ Imports:
     utils,
     yaml
 Suggests:
-    rlang,
     covr,
     devtools,
     dockerfiler (>= 0.1.4),

--- a/R/add_dockerfiles.R
+++ b/R/add_dockerfiles.R
@@ -71,9 +71,11 @@ add_dockerfile <- function(
   build_golem_from_source = TRUE,
   extra_sysreqs = NULL
 ) {
-  check_is_installed("dockerfiler")
-
-  required_version("dockerfiler", "0.1.4")
+  rlang::check_installed(
+    "dockerfiler",
+    "to create Dockerfile using {golem}.",
+    version = "0.1.4"
+  )
 
   where <- path(pkg, output)
 
@@ -142,8 +144,11 @@ add_dockerfile_shinyproxy <- function(
   build_golem_from_source = TRUE,
   extra_sysreqs = NULL
 ) {
-  check_is_installed("dockerfiler")
-  required_version("dockerfiler", "0.1.4")
+  rlang::check_installed(
+    "dockerfiler",
+    "to create Dockerfile using {golem}.",
+    version = "0.1.4"
+  )
 
   where <- path(pkg, output)
 
@@ -206,8 +211,11 @@ add_dockerfile_heroku <- function(
   build_golem_from_source = TRUE,
   extra_sysreqs = NULL
 ) {
-  check_is_installed("dockerfiler")
-  required_version("dockerfiler", "0.1.4")
+  rlang::check_installed(
+    "dockerfiler",
+    "to create Dockerfile using {golem}.",
+    version = "0.1.4"
+  )
 
   where <- path(pkg, output)
 

--- a/R/add_r_files.R
+++ b/R/add_r_files.R
@@ -67,7 +67,10 @@ add_r_files <- function(
   }
 
   if (with_test) {
-    check_is_installed("usethis")
+    rlang::check_installed(
+      "usethis",
+      "to build the test structure."
+    )
     usethis::use_test(
       basename(
         file_path_sans_ext(

--- a/R/modules_fn.R
+++ b/R/modules_fn.R
@@ -256,9 +256,17 @@ use_module_test <- function(
   }
 
   # We need both testthat, usethis & fs
-  check_is_installed("testthat")
-  check_is_installed("usethis")
-  check_is_installed("fs")
+  rlang::check_installed(
+    "usethis",
+    "to build the test structure."
+  )
+  rlang::check_installed(
+    "testthat",
+    "to build the test structure."
+  )
+  rlang::check_installed(
+    "fs"
+  )
 
   old <- setwd(fs::path_abs(pkg))
   on.exit(setwd(old))

--- a/R/test_helpers.R
+++ b/R/test_helpers.R
@@ -12,8 +12,10 @@
 #' @examples
 #' expect_shinytag(shiny::tags$span("1"))
 expect_shinytag <- function(object) {
-  check_is_installed("testthat")
-  check_is_installed("rlang")
+  rlang::check_installed(
+    "testthat",
+    "to run the tests."
+  )
   act <- testthat::quasi_label(rlang::enquo(object), arg = "object")
   act$class <- class(object)
   testthat::expect(
@@ -28,8 +30,11 @@ expect_shinytag <- function(object) {
 #' @examples
 #' expect_shinytaglist(shiny::tagList(1))
 expect_shinytaglist <- function(object) {
-  check_is_installed("testthat")
-  check_is_installed("rlang")
+  rlang::check_installed(
+    "testthat",
+    "to run the tests.",
+    version = "3.0.0"
+  )
   act <- testthat::quasi_label(rlang::enquo(object), arg = "object")
   act$class <- class(object)
   testthat::expect(
@@ -50,9 +55,11 @@ expect_html_equal <- function(
   html,
   ...
 ) {
-  check_is_installed("testthat")
-  required_version("testthat", "3.0.0")
-  check_is_installed("rlang")
+  rlang::check_installed(
+    "testthat",
+    "to run the tests.",
+    version = "3.0.0"
+  )
 
   if (!missing(html)) {
     message(
@@ -74,7 +81,11 @@ expect_running <- function(
   sleep,
   R_path = NULL
 ) {
-  check_is_installed("testthat")
+  rlang::check_installed(
+    "testthat",
+    "to run the tests.",
+    version = "3.0.0"
+  )
   testthat::skip_if_not_installed("pkgload")
   testthat::skip_if_not_installed("processx")
   testthat::skip_on_cran()

--- a/R/utils.R
+++ b/R/utils.R
@@ -405,44 +405,6 @@ yesno <- function(...) {
   menu(c("Yes", "No")) == 1
 }
 
-# Checking that a package is installed
-check_is_installed <- function(
-  pak,
-  ...
-) {
-  if (
-    !requireNamespace(pak, ..., quietly = TRUE)
-  ) {
-    stop(
-      sprintf(
-        "The {%s} package is required to run this function.\nYou can install it with `install.packages('%s')`.",
-        pak,
-        pak
-      ),
-      call. = FALSE
-    )
-  }
-}
-
-required_version <- function(
-  pak,
-  version
-) {
-  if (
-    utils::packageVersion(pak) < version
-  ) {
-    stop(
-      sprintf(
-        "This function require the version '%s' of the {%s} package.\nYou can update with `install.packages('%s')`.",
-        version,
-        pak,
-        pak
-      ),
-      call. = FALSE
-    )
-  }
-}
-
 #' @importFrom fs file_exists
 add_sass_code <- function(where, dir, name) {
   if (file_exists(where)) {


### PR DESCRIPTION
As rlang is imported by shiny, we can rely on it being available and not adding
YAD (yet another dependency)