### PR TITLE
fix: add normalizePath() inside set_golem_wd() check()

### DIFF
--- a/R/golem-yaml-set.R
+++ b/R/golem-yaml-set.R
@@ -6,9 +6,10 @@ set_golem_wd <- function(
   pkg = golem::pkg_path(),
   talkative = TRUE
 ) {
+
   if (
     golem_wd == "golem::pkg_path()" |
-      golem_wd == golem::pkg_path()
+     normalizePath(golem_wd) == normalizePath(golem::pkg_path())
   ) {
     golem_yaml_path <- "golem::pkg_path()"
     attr(golem_yaml_path, "tag") <- "!expr"
@@ -59,7 +60,7 @@ set_golem_name <- function(
     )
   )
   desc$set(
-    Package = as.character(name)
+    Package = name
   )
   desc$write(
     file = "DESCRIPTION"

--- a/R/pkg_tools.R
+++ b/R/pkg_tools.R
@@ -3,7 +3,8 @@ daf_desc <- function(
   path = ".",
   entry
 ) {
-  unlist(
+  as.character(
+    unlist(
     unname(
       as.data.frame(
         read.dcf(
@@ -13,6 +14,7 @@ daf_desc <- function(
         )
       )[entry]
     )
+  )
   )
 }
 

--- a/tests/testthat/helper-config.R
+++ b/tests/testthat/helper-config.R
@@ -71,7 +71,6 @@ unlink(file.path(tpdir, fakename), recursive = TRUE)
 create_golem(file.path(tpdir, fakename), open = FALSE)
 pkg <- file.path(tpdir, fakename)
 
-
 fp <- file.path("inst/app", randir)
 dir.create(file.path(pkg, fp), recursive = TRUE)
 
@@ -82,6 +81,8 @@ rand_name <- function() {
 withr::with_dir(pkg, {
   set_golem_options()
   usethis::proj_set(pkg)
-  orig_test <- set_golem_wd(pkg)
+  orig_test <- set_golem_wd(
+    pkg = pkg,
+    )
   usethis::use_mit_license("Golem")
 })


### PR DESCRIPTION
- There was an issue with comparison of path on windows (issue with `/` & `\`

- Force `daf_desc `to return string instead of a factor 