### PR TITLE
doc: Added min version for rlang

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Imports:
     here,
     fs,
     htmltools,
-    rlang,
+    rlang (>= 1.0.0),
     rstudioapi,
     shiny (>= 1.5.0),
     usethis (>= 1.6.0),


### PR DESCRIPTION
To use rlang::check_install(version = ), we need at least {rlang) 1.0.0

Close #905