### PR TITLE
fix: unit test requires dependencies in suggests

### DIFF
--- a/tests/testthat/test-extra_sysreqs.R
+++ b/tests/testthat/test-extra_sysreqs.R
@@ -1,3 +1,5 @@
+skip_if_not_installed("dockerfiler", minimum_version = "0.2.0")
+
 test_that("test extra sysreqs", {
   with_dir(pkg, {
     for (fun in list(

--- a/tests/testthat/test-pkg_tools.R
+++ b/tests/testthat/test-pkg_tools.R
@@ -1,9 +1,11 @@
+skip_if_not_installed("pkgload")
+
 test_that("pkgtools works", {
   withr::with_dir(pkg, {
-    expect_equal(pkg_name(), fakename)
-    expect_equal(pkg_version(), "0.0.0.9000")
+    expect_equal(pkgload::pkg_name(), fakename)
+    expect_equal(as.character(pkgload::pkg_version()), "0.0.0.9000")
     # F-word windows path
     skip_on_os("windows")
-    expect_equal(pkg_path(), pkg)
+    expect_equal(pkgload::pkg_path(), pkg)
   })
 })


### PR DESCRIPTION
tags: fix, test

Why?

- On a fresh install, you may not have all dependencies to run all unit tests. For instance with {dockerfiler} here

What?

- Update unit tests for skip if not dockerfiler
- Update unit test for functions needing {pkgload} which is not loaded by default
- pkg_version as changed its format. Need to change as character for correct test