### PR TITLE
Add a demo shinyapps.io snippet for the _03_deploy_ file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: golem
 Title: A Framework for Robust Shiny Applications
-Version: 0.3.5.9000
+Version: 0.3.5.9001
 Authors@R: 
     c(person(given = "Colin",
              family = "Fay",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 # 0.3.5.9000+ (dev version)
 
+add_dockerfile_with_renv now works well with uppercase in package name
+
+
 # golem 0.3.5
 
 Update in the tests for CRAN (commented a test that made new version of testthat fail).

--- a/R/add_dockerfiles_renv.R
+++ b/R/add_dockerfiles_renv.R
@@ -47,12 +47,12 @@ add_dockerfile_with_renv_ <- function(
     )
   }
 
-  fs_file_copy(
-    path = lockfile,
-    new_path = output_dir,
-    overwrite = TRUE
-  )
-
+  # fs_file_copy(
+  #   path = lockfile,
+  #   new_path = output_dir,
+  #   overwrite = TRUE
+  # )
+  file.copy(from = lockfile, to = output_dir)
   socle <- dockerfiler::dock_from_renv(
     lockfile = lockfile,
     distro = distro,
@@ -66,7 +66,7 @@ add_dockerfile_with_renv_ <- function(
 
   socle$write(as = file.path(output_dir, "Dockerfile_base"))
 
-  my_dock <- dockerfiler::Dockerfile$new(FROM = paste0(golem::get_golem_name(), "_base"))
+  my_dock <- dockerfiler::Dockerfile$new(FROM = tolower(paste0(golem::get_golem_name(), "_base")))
 
   my_dock$COPY("renv.lock.prod", "renv.lock")
 
@@ -191,11 +191,11 @@ add_dockerfile_with_renv <- function(
 docker build -f Dockerfile --progress=plain -t %s .
 docker run -p %s:%s %s
 # then go to 127.0.0.1:%s",
-    paste0(golem::get_golem_name(), "_base"),
-    paste0(golem::get_golem_name(), ":latest"),
+    tolower(paste0(golem::get_golem_name(), "_base")),
+    tolower( paste0(golem::get_golem_name(), ":latest")),
     port,
     port,
-    paste0(golem::get_golem_name(), ":latest"),
+    tolower(paste0(golem::get_golem_name(), ":latest")),
     port
   )
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -386,6 +386,48 @@ yesno <- function(...) {
   menu(c("Yes", "No")) == 1
 }
 
+
+# Checking that a package is installed
+check_is_installed <- function(
+    pak,
+    ...
+) {
+  if (
+    !requireNamespace(pak, ..., quietly = TRUE)
+  ) {
+    stop(
+      sprintf(
+        "The {%s} package is required to run this function.\nYou can install it with `install.packages('%s')`.",
+        pak,
+        pak
+      ),
+      call. = FALSE
+    )
+  }
+}
+
+required_version <- function(
+    pak,
+    version
+) {
+  if (
+    utils::packageVersion(pak) < version
+  ) {
+    stop(
+      sprintf(
+        "This function require the version '%s' of the {%s} package.\nYou can update with `install.packages('%s')`.",
+        version,
+        pak,
+        pak
+      ),
+      call. = FALSE
+    )
+  }
+}
+
+
+
+
 add_sass_code <- function(where, dir, name) {
   if (fs_file_exists(where)) {
     if (fs_file_exists("dev/run_dev.R")) {

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -25,7 +25,7 @@ reference:
 
   - title: Create a Dockerfile
     desc: |
-      Build a container containing your Shiny App. `add_dockerfile()` creates a "classical" Dockerfile, 
+      Build a container containing your Shiny App. `add_dockerfile()` creates a "classical" Dockerfile,
       while `add_dockerfile_shinyproxy()` and `add_dockerfile_heroku()` creates platform specific Dockerfile.
     contents:
       - add_dockerfile
@@ -34,7 +34,7 @@ reference:
 
   - title: Use files
     desc: |
-      `use_external_js_file` and `use_external_css_file`download files from external sources and install 
+      `use_external_js_file` and `use_external_css_file`download files from external sources and install
       them inside the appropriate directory. `use_utils_ui` copies the golem_utils_ui.R to the R folder and `use_utils_server`
       copies the golem_utils_server.R to the R folder.
     contents:
@@ -88,7 +88,7 @@ reference:
 
   - title: Addins
     desc: |
-      `insert_ns()` takes a selected character vector and wrap it in `ns()`. The series of `go_to_*()` 
+      `insert_ns()` takes a selected character vector and wrap it in `ns()`. The series of `go_to_*()`
       addins help you go to common files used in developing a {golem} application.
     contents:
       - insert_ns
@@ -102,7 +102,7 @@ reference:
 
   - title: JavaScript interaction functions
     desc: |
-      `activate_js` is used in your UI to insert directly the JavaScript functions contained in golem. 
+      `activate_js` is used in your UI to insert directly the JavaScript functions contained in golem.
       These functions can be called from the server with `invoke_js`. `invoke_js` can also be used to launch
       any JS function created inside a Shiny JavaScript handler.
     contents:
@@ -111,7 +111,7 @@ reference:
 
   - title: Options
     desc: |
-      Set and get a series of options to be used with `{golem}`. These options are found inside the 
+      Set and get a series of options to be used with `{golem}`. These options are found inside the
       `golem-config.yml` file, found in most cases inside the inst folder.
     contents:
       - set_golem_options
@@ -126,9 +126,11 @@ reference:
     desc: |
       `use_recommended_deps` adds shiny, DT, attempt, glue, golem, htmltools to dependencies
       `use_recommended_tests` adds a test folder and copy the golem tests
+      `install_dev_deps` install all packages needed for golem developpement
     contents:
       - use_recommended_deps
       - use_recommended_tests
+      - install_dev_deps
 
   - title: Misc
     contents:
@@ -157,3 +159,5 @@ reference:
       - sanity_check
       - js_handler_template
       - use_module_test
+      - get_current_config
+      - pkg_name

--- a/inst/shinyexample/dev/03_deploy.R
+++ b/inst/shinyexample/dev/03_deploy.R
@@ -38,3 +38,23 @@ golem::add_dockerfile_with_renv()
 ## If you want to deploy to ShinyProxy
 golem::add_dockerfile_with_renv_shinyproxy()
 
+## ShinyApps.io Demo Deployment Snippet
+# If you want to deploy to ShinyApps.io without using the built in RStudio workflow
+rsconnect::deployApp(
+  appName = desc::desc_get_field("Package"),
+  appTitle = desc::desc_get_field("Package"),
+  appFiles = c(
+    # Add any additional files unique to your app here.
+    "R/",
+    "inst/",
+    "data/",
+    "NAMESPACE",
+    "DESCRIPTION",
+    "app.R",
+    ".Rprofile",
+    ".Renviron"
+  ),
+  appId = rsconnect::deployments(".")$appID,
+  lint = FALSE,
+  forceUpdate = TRUE
+)


### PR DESCRIPTION
As per @ColinFay 's request in #923, adds a snippet to _03_deploy.R_ that will deploy most shiny apps to shinyapps.io without the use of the RStudio built in workflow