### PR TITLE
Pass `require_suggests` to `attachment_create_renv_for_prod`

### DIFF
--- a/R/add_dockerfiles_renv.R
+++ b/R/add_dockerfiles_renv.R
@@ -33,6 +33,7 @@ add_dockerfile_with_renv_ <- function(
   if (is.null(lockfile)) {
     lockfile <- attachment_create_renv_for_prod(
       path = source_folder,
+      require_suggests = FALSE,
       output = file.path(output_dir, "renv.lock.prod")
     )
   }


### PR DESCRIPTION
Related to https://github.com/ThinkR-open/attachment/pull/69
This passes `require_suggests = FALSE` to `attachment_create_renv_for_prod` to turn off the requirement that Suggests packages be installed for deployment