### PR TITLE
fix: allow to build readme in 01_start

### DIFF
--- a/inst/shinyexample/dev/01_start.R
+++ b/inst/shinyexample/dev/01_start.R
@@ -39,6 +39,7 @@ golem::install_dev_deps()
 ## See ?usethis for more information
 usethis::use_mit_license("Golem User") # You can set another license here
 usethis::use_readme_rmd(open = FALSE)
+devtools::build_readme()
 # Note that `contact` is required since usethis version 2.1.5
 # If your {usethis} version is older, you can remove that param
 usethis::use_code_of_conduct(contact = "Golem User")


### PR DESCRIPTION
tags: fix, doc

Why?  

- I need to be able to commit right after running the complete "dev/01_dev.R"

How?

- To commit, I need the Readme.md file to be created, after I created the Readme.Rmd file.
- devtools::build_readme() allows to install the package temporarily with its last version to be able to knit the Readme.Rmd in the last good conditions