### PR TITLE
Fix #993

### DIFF
--- a/inst/shinyexample/REMOVEME.Rbuildignore
+++ b/inst/shinyexample/REMOVEME.Rbuildignore
@@ -4,3 +4,4 @@
 dev_history.R
 ^dev$
 $run_dev.*
+^.here$


### PR DESCRIPTION
Add `.here` to `inst/shinyexample/REMOVEME.Rbuildignore` to pass `R CMD check` without notes.