### PR TITLE
Fix 1004 - add function body upon call to add_fct

### DIFF
--- a/R/add_r_files.R
+++ b/R/add_r_files.R
@@ -182,11 +182,7 @@ append_roxygen_comment <- function(
     write_there("#' @noRd")
   }
   if (file_type == "function") {
-    write_there(paste(name, "<- function(arg1, arg2, ...) {"))
-    write_there("#  ... some computations ...")
-    write_there("#  ... final compuations ...")
-    write_there("")
-    write_there("  return(NULL)")
+    write_there(paste(name, "<- function(arg1, arg2) {"))
     write_there("}")
   }
 }

--- a/R/add_r_files.R
+++ b/R/add_r_files.R
@@ -168,11 +168,25 @@ append_roxygen_comment <- function(
   write_there("#'")
   write_there(sprintf("#' @description A %s function", ext))
   write_there("#'")
+  if (file_type == "function") {
+    write_there("#' @param arg1 first function argument")
+    write_there("#'")
+    write_there("#' @param arg2 second function argument")
+    write_there("#'")
+  }
   write_there(sprintf("#' @return The return value, if any, from executing the %s.", file_type))
   write_there("#'")
   if (export) {
     write_there("#' @export")
   } else {
     write_there("#' @noRd")
+  }
+  if (file_type == "function") {
+    write_there(paste(name, "<- function(arg1, arg2, ...) {"))
+    write_there("#  ... some computations ...")
+    write_there("#  ... final compuations ...")
+    write_there("")
+    write_there("  return(NULL)")
+    write_there("}")
   }
 }


### PR DESCRIPTION
Per commit message:

- fix #1004 adding bare skeleton function body
- function name taken from 'name' arg to add_fct

So `add_module(fct = "fct_name")` creates a file "fct_name" without pulling above template. This could be fixed, though I am not sure what the exact behavior should be. #1004 explicitly asks for changing `add_fct()`  not `add_module()`.

The body is a matter of taste, I am happy to change it :)