### PR TITLE
Fix 997 

### DIFF
--- a/R/add_r_files.R
+++ b/R/add_r_files.R
@@ -30,14 +30,18 @@ add_r_files <- function(
     # Remove the "mod_" if any
     module <- mod_remove(module)
     if (!is_existing_module(module)) {
-      stop(
-        sprintf(
-          "The module '%s' does not exist.\nYou can call `golem::add_module('%s')` to create it.",
-          module,
-          module
-        ),
-        call. = FALSE
-      )
+      # Check for esoteric 'mod_mod_' module names and if that fails throw error
+      if (!is_existing_module(paste0("mod_", module))) {
+        stop(
+          sprintf(
+            "The module '%s' does not exist.\nYou can call `golem::add_module('%s')` to create it.",
+            module,
+            module
+          ),
+          call. = FALSE
+        )
+      }
+      module <- paste0("mod_", module)
     }
     module <- paste0("mod_", module, "_")
   }

--- a/R/modules_fn.R
+++ b/R/modules_fn.R
@@ -40,6 +40,7 @@ add_module <- function(
 ) {
   check_name_length(name)
   name <- file_path_sans_ext(name)
+  name <- check_name_syntax(name)
 
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))

--- a/R/utils.R
+++ b/R/utils.R
@@ -508,3 +508,31 @@ do_if_unquiet <- function(expr) {
     force(expr)
   }
 }
+
+# This functions checks that the 'name' argument
+# of add_module() does not start with 'mod_' as
+# this is prepended by add_module() per default.
+check_name_syntax <- function(name) {
+  check_mod <- grepl("^mod_", name)
+  name_proposed <- gsub("^mod_", "", name)
+  if (isTRUE(check_mod)) {
+    msg <- paste0(
+      "Argument 'name' starts with 'mod_' but {golem} prepends 'mod_' to your",
+      " module name automatically.\nDo you want to name your module: "
+    )
+    cat(msg)
+    ask <- menu(paste0("'mod_", c(name_proposed, name), "'?"))
+    if (ask == 1) {
+      return(name_proposed)
+    } else if (ask == 2) {
+      # optional
+      # message("Keeping name: '", name, "' as module name.")
+      return(name)
+    } else {
+      warning("Could not check name syntax properly ...")
+      return(invisible(name))
+    }
+  } else {
+    return(name)
+  }
+}


### PR DESCRIPTION
Fix #997 in two possible ways:

1. add a double check to look for modules with names starting with "mod_mod_xxx" (see R/add_r_files.R)

2. add syntax check for module names to add_module(): explicitly ask the user if s/he wants to name her module "mod_xxx" or "mod_mod_xxx"

@1. it's a bit clumsy but does the job
@2. I added this because sometimes users (at least me) simply forget that `add_module()` prepends "mod_" explicitly to each file

Can provide tests if this thing ever gets useful/merged.