### PR TITLE
Add call to usethis::use_git_remote()

### DIFF
--- a/inst/shinyexample/dev/01_start.R
+++ b/inst/shinyexample/dev/01_start.R
@@ -48,6 +48,10 @@ usethis::use_news_md(open = FALSE)
 
 ## Use git ----
 usethis::use_git()
+## Sets the remote associated with 'name' to 'url'
+usethis::use_git_remote(
+  name = "origin",
+  url = "https://github.com/<OWNER>/<REPO>.git")
 
 ## Init Testing Infrastructure ----
 ## Create a template for tests


### PR DESCRIPTION
Fix #1012 

Per the issue, it's probably 02, not 01, i.e. `02_dev.R`.

- one might want to separate the Github and CI part as the Github part now has `use_github` and `use_git_remote`, and one might want to have Github but not the CI part
- `use_git_remote` has to set a default URL; the current PR takes the `url = "https://github.com/<OWNER>/<REPO>.git"` as the in the examples section of this function
- I am not 100% sure which style the comments follow; it's either a double `##` or a single `#`