### PR TITLE
fix: rely on get_golem_wd where useful

### DIFF
--- a/R/add_dockerfiles_renv.R
+++ b/R/add_dockerfiles_renv.R
@@ -141,15 +141,15 @@ add_dockerfile_with_renv_ <- function(
 }
 
 #' @param source_folder path to the Package/golem source folder to deploy.
-#' default is current folder '.'
-#' @param lockfile path to the renv.lock file to use. default is `NULL`
+#' default is retrieved via [get_golem_wd()].
+#' @param lockfile path to the renv.lock file to use. default is `NULL`.
 #' @param output_dir folder to export everything deployment related.
 #' @param distro One of "focal", "bionic", "xenial", "centos7", or "centos8".
 #' See available distributions at https://hub.docker.com/r/rstudio/r-base/.
 #' @param document boolean. If TRUE (by default), DESCRIPTION file is updated using [attachment::att_amend_desc()] before creating the renv.lock file
 #' @param dockerfile_cmd What is the CMD to add to the Dockerfile. If NULL, the default,
-#' the CMD will be `R -e "options('shiny.port'={port},shiny.host='{host}');library({appname});{appname}::run_app()\`
-#' @param ... Other arguments to pass to [renv::snapshot()]
+#' the CMD will be `R -e "options('shiny.port'={port},shiny.host='{host}');library({appname});{appname}::run_app()\`.
+#' @param ... Other arguments to pass to [renv::snapshot()].
 #' @inheritParams add_dockerfile
 #' @rdname dockerfiles
 #' @export

--- a/R/add_dockerfiles_renv.R
+++ b/R/add_dockerfiles_renv.R
@@ -1,5 +1,5 @@
 add_dockerfile_with_renv_ <- function(
-    source_folder = ".",
+    source_folder = get_golem_wd(),
     lockfile = NULL,
     output_dir = fs::path(tempdir(), "deploy"),
     distro = "focal",
@@ -110,7 +110,7 @@ add_dockerfile_with_renv_ <- function(
       )
     ) {
       out <- pkgbuild::build(
-        path = ".",
+        path = source_folder,
         dest_path = output_dir,
         vignettes = FALSE
       )
@@ -154,7 +154,7 @@ add_dockerfile_with_renv_ <- function(
 #' @rdname dockerfiles
 #' @export
 add_dockerfile_with_renv <- function(
-    source_folder = ".",
+    source_folder = get_golem_wd(),
     lockfile = NULL,
     output_dir = fs::path(tempdir(), "deploy"),
     distro = "focal",
@@ -229,7 +229,7 @@ docker run -p %s:%s %s
 #' @export
 #' @export
 add_dockerfile_with_renv_shinyproxy <- function(
-    source_folder = ".",
+    source_folder = get_golem_wd(),
     lockfile = NULL,
     output_dir = fs::path(tempdir(), "deploy"),
     distro = "focal",
@@ -272,7 +272,7 @@ add_dockerfile_with_renv_shinyproxy <- function(
 #' @export
 #' @export
 add_dockerfile_with_renv_heroku <- function(
-    source_folder = ".",
+    source_folder = get_golem_wd(),
     lockfile = NULL,
     output_dir = fs::path(tempdir(), "deploy"),
     distro = "focal",

--- a/R/config.R
+++ b/R/config.R
@@ -60,7 +60,7 @@ guess_where_config <- function(
 #' @param path Path to start looking for the config
 #'
 #' @export
-get_current_config <- function(path = get_golem_wd()) {
+get_current_config <- function(path = getwd()) {
   # We check whether we can guess where the config file is
   path_conf <- guess_where_config(path)
 

--- a/R/config.R
+++ b/R/config.R
@@ -9,7 +9,7 @@
 
 #' @importFrom attempt attempt is_try_error
 guess_where_config <- function(
-  path = get_golem_wd(),
+  path = golem::pkg_path(),
   file = "inst/golem-config.yml"
 ) {
   # We'll try to guess where the path

--- a/R/config.R
+++ b/R/config.R
@@ -9,7 +9,7 @@
 
 #' @importFrom attempt attempt is_try_error
 guess_where_config <- function(
-  path = golem::pkg_path(),
+  path = get_golem_wd(),
   file = "inst/golem-config.yml"
 ) {
   # We'll try to guess where the path
@@ -60,8 +60,8 @@ guess_where_config <- function(
 #' @param path Path to start looking for the config
 #'
 #' @export
-get_current_config <- function(path = getwd()) {
-  # We check wether we can guess where the config file is
+get_current_config <- function(path = get_golem_wd()) {
+  # We check whether we can guess where the config file is
   path_conf <- guess_where_config(path)
 
   # We default to inst/ if this doesn't exist

--- a/R/pkg_tools.R
+++ b/R/pkg_tools.R
@@ -1,6 +1,6 @@
 # Getting the DESCRIPTION file in a data.frame
 daf_desc <- function(
-    path = ".",
+    path = get_golem_wd(),
     entry) {
   as.character(
     unlist(
@@ -28,12 +28,12 @@ daf_desc <- function(
 #' @rdname pkg_tools
 #'
 #' @return The value of the entry in the DESCRIPTION file
-pkg_name <- function(path = ".") {
+pkg_name <- function(path = get_golem_wd()) {
   daf_desc(path, "Package")
 }
 #' @export
 #' @rdname pkg_tools
-pkg_version <- function(path = ".") {
+pkg_version <- function(path = get_golem_wd()) {
   daf_desc(path, "Version")
 }
 #' @export


### PR DESCRIPTION
This PR should fix #844 

- files that receive a change are referenced in the commits in turn
- files not changed (still have an ".") are the bootstrap_type funcs.:
    -  `attachment_create_renv_for_prod`
    - `pkgload_load_all`
    - `roxygen2_roxygenise`
    - `usethis_proj_set`
    - `enable_roxygenize`

Not sure about those, they are all unexported and called internally, probably with correct argument passing from the top level functions that should now have all the `get_golem_wd()`.