### PR TITLE
Rename from rstudioconnect to positconnect

### DIFF
--- a/R/add_rstudio_files.R
+++ b/R/add_rstudio_files.R
@@ -67,10 +67,10 @@ add_rstudio_files <- function(
 #' Add an app.R at the root of your package to deploy on RStudio Connect
 #'
 #' @note
-#' In previous versions, this function was called add_rconnect_file.
+#' In previous versions, this function was called add_rconnect_file and add_rstudioconnect_file.
 #'
 #' @inheritParams add_module
-#' @aliases add_rconnect_file add_rstudioconnect_file
+#' @aliases add_rconnect_file add_rstudioconnect_file add_positconnect_file
 #' @export
 #'
 #' @rdname rstudio_deploy
@@ -80,7 +80,7 @@ add_rstudio_files <- function(
 #' @examples
 #' # Add a file for Connect
 #' if (interactive()) {
-#'   add_rstudioconnect_file()
+#'   add_positconnect_file()
 #' }
 #' # Add a file for Shiny Server
 #' if (interactive()) {
@@ -90,7 +90,7 @@ add_rstudio_files <- function(
 #' if (interactive()) {
 #'   add_shinyappsio_file()
 #' }
-add_rstudioconnect_file <- function(
+add_positconnect_file <- function(
   pkg = get_golem_wd(),
   open = TRUE
 ) {
@@ -99,6 +99,16 @@ add_rstudioconnect_file <- function(
     open = open,
     service = "RStudio Connect"
   )
+}
+
+#' @rdname rstudio_deploy
+#' @note `add_rstudioconnect_file` is now deprecated; replace by [add_positconnect_file()].
+#' @export
+add_rstudioconnect_file <- function(pkg = get_golem_wd(),
+                                    open = TRUE){
+  .Deprecated("add_positconnect_file")
+  add_positconnect_file(pkg = get_golem_wd(),
+                         open = TRUE)
 }
 
 #' @rdname rstudio_deploy

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -52,7 +52,7 @@ reference:
   - title: Add an app.R
     desc: Add an app.R at the root of your package to deploy on RStudio Connect
     contents:
-      - add_rstudioconnect_file
+      - add_positconnect_file
       - add_shinyappsio_file
       - add_shinyserver_file
 

--- a/inst/mantests/build.R
+++ b/inst/mantests/build.R
@@ -390,7 +390,7 @@ remotes::install_local(targz, force = TRUE, upgrade = FALSE)
 
 cat_ok()
 
-golem::add_rstudioconnect_file()
+golem::add_positconnect_file()
 
 golem::add_dockerfile_with_renv(
   repos = "https://packagemanager.rstudio.com/all/__linux__/focal/latest",

--- a/inst/shinyexample/dev/03_deploy.R
+++ b/inst/shinyexample/dev/03_deploy.R
@@ -27,7 +27,7 @@ devtools::build()
 
 ## RStudio ----
 ## If you want to deploy on RStudio related platforms
-golem::add_rstudioconnect_file()
+golem::add_positconnect_file()
 golem::add_shinyappsio_file()
 golem::add_shinyserver_file()
 

--- a/tests/testthat/test-add_deploy_helpers.R
+++ b/tests/testthat/test-add_deploy_helpers.R
@@ -94,7 +94,7 @@ test_that("add_dockerfiles repos variation", {
 test_that("add_rstudio_files", {
   with_dir(pkg, {
     for (fun in list(
-      add_rstudioconnect_file,
+      add_positconnect_file,
       add_shinyappsio_file,
       add_shinyserver_file
     )) {

--- a/vignettes/c_deploy.Rmd
+++ b/vignettes/c_deploy.Rmd
@@ -58,7 +58,7 @@ The `dev/03_deploy.R` file contains function for deploying on various platforms.
 ### RStudio Products
 
 ```{r}
-golem::add_rstudioconnect_file()
+golem::add_positconnect_file()
 golem::add_shinyappsio_file()
 golem::add_shinyserver_file()
 ```


### PR DESCRIPTION
Fix #888

rename add_rstudioconnect_file() to add_positconnect_file() in files:

- add_rstudio_files.R
- vignettes/c_deploy.Rmd
- tests/testthat/test-add_deploy_helpers.R
- inst/mantest/build.R
- inst/shinyexamle/dev/03_deploy.R
- _pkgdown.yml

Not touching NAMESPACE, .Rd-files, and NEWS.md as they are updated otherwise.