### PR TITLE
draft : fix : now user can kill container with ^C

### DIFF
--- a/R/add_dockerfiles_renv.R
+++ b/R/add_dockerfiles_renv.R
@@ -206,7 +206,7 @@ add_dockerfile_with_renv <- function(
   out <- sprintf(
     "docker build -f Dockerfile_base --progress=plain -t %s .
 docker build -f Dockerfile --progress=plain -t %s .
-docker run -p %s:%s %s
+docker run -it -p %s:%s %s
 # then go to 127.0.0.1:%s",
     tolower(paste0(golem::get_golem_name(), "_base")),
     tolower(paste0(golem::get_golem_name(), ":latest")),


### PR DESCRIPTION
how: add -it in README generated  golem::add_dockerfile_with_renv()

issue #1001