### PR TITLE
819 - refactor use_files.R before adding replace arg

### DIFF
--- a/R/use_files.R
+++ b/R/use_files.R
@@ -27,54 +27,29 @@ use_external_js_file <- function(
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
-  if (missing(name)) {
-    name <- basename(url)
-  }
+  name <- get_new_name(name)
 
-  check_name_length_is_one(name)
+  new_file <- get_new_file(
+    name,
+    type = "js")
 
-  name <- file_path_sans_ext(name)
-  new_file <- sprintf("%s.js", name)
-
-  dir_created <- tryCatch(
-    create_if_needed(
-      dir,
-      type = "directory"
-    ),
-    error = function(e) {
-      out <- FALSE
-      names(out) <- e[[1]]
-      return(out)
-    }
-  )
-
-  if (isFALSE(dir_created)) {
-    cat_dir_necessary()
-    return(invisible(FALSE))
-  }
-
-  dir <- fs_path_abs(dir)
+  dir <- get_new_dir(dir)
+  if (isFALSE(dir)) return(invisible(FALSE))
 
   where <- fs_path(
     dir,
     new_file
   )
 
-  if (fs_file_exists(where)) {
-    cat_exists(where)
-    return(invisible(FALSE))
-  }
+  check_file <- check_file_exists(where)
+  if (isFALSE(check_file)) return(invisible(FALSE))
 
-  if (file_ext(url) != "js") {
-    cat_red_bullet(
-      "File not added (URL must end with .js extension)"
-    )
-    return(invisible(FALSE))
-  }
+  check_url <- check_url_valid(
+    url,
+    type = "js")
+  if (isFALSE(check_url)) return(invisible(FALSE))
 
-  cat_start_download()
-
-  utils::download.file(url, where)
+  download_external(url, where)
 
   file_created_dance(
     where,
@@ -101,54 +76,60 @@ use_external_css_file <- function(
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
-  if (missing(name)) {
-    name <- basename(url)
-  }
+  name <- get_new_name(name)
+  # previously:
+  # check_name_length(name)
+  # name <- file_path_sans_ext(name)
+  # if (missing(name)) {
+  #   name <- basename(url)
+  # }
 
-  check_name_length_is_one(name)
+  new_file <- get_new_file(
+    name,
+    type = "css")
+  # previously
+  # new_file <- sprintf("%s.css", name)
 
-  name <- file_path_sans_ext(name)
-  new_file <- sprintf("%s.css", name)
-
-  dir_created <- tryCatch(
-    create_if_needed(
-      dir,
-      type = "directory"
-    ),
-    error = function(e) {
-      out <- FALSE
-      names(out) <- e[[1]]
-      return(out)
-    }
-  )
-
-  if (isFALSE(dir_created)) {
-    cat_dir_necessary()
-    return(invisible(FALSE))
-  }
-
-  dir <- fs_path_abs(dir)
+  dir <- get_new_dir(dir)
+  if (isFALSE(dir)) return(invisible(FALSE))
+  # previously
+  # dir_created <- create_if_needed(
+  #   dir,
+  #   type = "directory"
+  # )
+  # if (!dir_created) {
+  #   cat_dir_necessary()
+  #   return(invisible(FALSE))
+  # }
+  # dir <- fs_path_abs(dir)
 
   where <- fs_path(
     dir,
     new_file
   )
+  # no change to previous version
 
-  if (fs_file_exists(where)) {
-    cat_exists(where)
-    return(invisible(FALSE))
-  }
+  check_file <- check_file_exists(where)
+  if (isFALSE(check_file)) return(invisible(FALSE))
+  # previously
+  # if (fs_file_exists(where)) {
+  #   cat_exists(where)
+  #   return(invisible(FALSE))
+  # }
 
-  if (file_ext(url) != "css") {
-    cat_red_bullet(
-      "File not added (URL must end with .css extension)"
-    )
-    return(invisible(FALSE))
-  }
+  check_url <- check_url_valid(
+    url,
+    type = "css")
+  if (isFALSE(check_url)) return(invisible(FALSE))
+  # previously:
+  # if (file_ext(url) != "css") {
+  #   cat_red_bullet(
+  #     "File not added (URL must end with .css extension)"
+  #   )
+  #   return(invisible(FALSE))
+  # }
 
-  cat_start_download()
-
-  utils::download.file(url, where)
+  download_external(url, where)
 
   file_created_dance(
     where,
@@ -547,4 +528,63 @@ use_internal_file <- function(
   fs_file_copy(path, where)
 
   cat_copied(where)
+}
+get_new_name <- function(
+  name
+) {
+  if (missing(name)) {
+    name <- basename(url)
+  }
+  check_name_length(name)
+  file_path_sans_ext(name)
+}
+get_new_file <- function(
+  name,
+  type = c("js", "css", "html")
+) {
+  tmp <- paste0("%s.", type)
+  sprintf(tmp, name)
+}
+get_new_dir <- function(
+  dir
+) {
+  dir_created <- create_if_needed(
+    dir,
+    type = "directory"
+  )
+
+  if (!dir_created) {
+    cat_dir_necessary()
+    return(invisible(FALSE))
+  }
+
+  fs_path_abs(dir)
+}
+check_file_exists <- function(where) {
+  if (fs_file_exists(where)) {
+    cat_exists(where)
+    return(invisible(FALSE))
+  }
+}
+check_url <- function(
+  url,
+  type = c("js", "css")
+) {
+  if (file_ext(url) != type) {
+    msg <- paste0(
+      "File not added (URL must end with .",
+      type,
+      " extension)")
+    cat_red_bullet(
+      msg
+    )
+    return(invisible(FALSE))
+  }
+}
+download_external <- function(
+  url,
+  where
+) {
+  cat_start_download()
+  utils::download.file(url, where)
 }

--- a/R/use_files.R
+++ b/R/use_files.R
@@ -33,10 +33,13 @@ use_external_js_file <- function(
 
   new_file <- get_new_file(
     name,
-    type = "js")
+    type = "js"
+  )
 
   dir <- get_new_dir(dir)
-  if (isFALSE(dir)) return(invisible(FALSE))
+  if (isFALSE(dir)) {
+    return(invisible(FALSE))
+  }
 
   where <- fs_path(
     dir,
@@ -44,12 +47,17 @@ use_external_js_file <- function(
   )
 
   check_file <- check_file_exists(where, overwrite)
-  if (isFALSE(check_file)) return(invisible(FALSE))
+  if (isFALSE(check_file)) {
+    return(invisible(FALSE))
+  }
 
   check_url <- check_url_valid(
     url,
-    type = "js")
-  if (isFALSE(check_url)) return(invisible(FALSE))
+    type = "js"
+  )
+  if (isFALSE(check_url)) {
+    return(invisible(FALSE))
+  }
 
   download_external(url, where)
 
@@ -89,12 +97,15 @@ use_external_css_file <- function(
 
   new_file <- get_new_file(
     name,
-    type = "css")
+    type = "css"
+  )
   # previously
   # new_file <- sprintf("%s.css", name)
 
   dir <- get_new_dir(dir)
-  if (isFALSE(dir)) return(invisible(FALSE))
+  if (isFALSE(dir)) {
+    return(invisible(FALSE))
+  }
   # previously
   # dir_created <- create_if_needed(
   #   dir,
@@ -113,7 +124,9 @@ use_external_css_file <- function(
   # no change to previous version
 
   check_file <- check_file_exists(where, overwrite)
-  if (isFALSE(check_file)) return(invisible(FALSE))
+  if (isFALSE(check_file)) {
+    return(invisible(FALSE))
+  }
   # previously
   # if (fs_file_exists(where)) {
   #   cat_exists(where)
@@ -122,8 +135,11 @@ use_external_css_file <- function(
 
   check_url <- check_url_valid(
     url,
-    type = "css")
-  if (isFALSE(check_url)) return(invisible(FALSE))
+    type = "css"
+  )
+  if (isFALSE(check_url)) {
+    return(invisible(FALSE))
+  }
   # previously:
   # if (file_ext(url) != "css") {
   #   cat_red_bullet(
@@ -170,12 +186,15 @@ use_external_html_template <- function(
 
   new_file <- get_new_file(
     name,
-    type = "css")
+    type = "css"
+  )
   # previously
   # new_file <- sprintf("%s.css", name)
 
   dir <- get_new_dir(dir)
-  if (isFALSE(dir)) return(invisible(FALSE))
+  if (isFALSE(dir)) {
+    return(invisible(FALSE))
+  }
   # previously
   # dir_created <- create_if_needed(
   #   dir,
@@ -193,7 +212,9 @@ use_external_html_template <- function(
   # no change to previous version
 
   check_file <- check_file_exists(where, overwrite)
-  if (isFALSE(check_file)) return(invisible(FALSE))
+  if (isFALSE(check_file)) {
+    return(invisible(FALSE))
+  }
   # previously
   # if (fs_file_exists(where)) {
   #   cat_exists(where)
@@ -249,7 +270,9 @@ use_external_file <- function(
   # }
 
   dir <- get_new_dir(dir)
-  if (isFALSE(dir)) return(invisible(FALSE))
+  if (isFALSE(dir)) {
+    return(invisible(FALSE))
+  }
   # previously:
   # dir_created <- create_if_needed(
   #   dir,
@@ -267,7 +290,9 @@ use_external_file <- function(
   )
 
   check_file <- check_file_exists(where, overwrite)
-  if (isFALSE(check_file)) return(invisible(FALSE))
+  if (isFALSE(check_file)) {
+    return(invisible(FALSE))
+  }
   # previously
   # if (fs_file_exists(where)) {
   #   cat_exists(where)
@@ -289,7 +314,7 @@ use_internal_js_file <- function(
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
-    ) {
+) {
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
@@ -362,7 +387,7 @@ use_internal_css_file <- function(
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
-    ) {
+) {
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
@@ -435,7 +460,7 @@ use_internal_html_template <- function(
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
-    ) {
+) {
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
@@ -500,7 +525,7 @@ use_internal_file <- function(
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
-    ) {
+) {
   if (missing(name)) {
     name <- basename(path)
   }
@@ -546,8 +571,7 @@ use_internal_file <- function(
   cat_copied(where)
 }
 get_new_name <- function(
-  name
-) {
+  name) {
   if (missing(name)) {
     name <- basename(url)
   }
@@ -562,8 +586,7 @@ get_new_file <- function(
   sprintf(tmp, name)
 }
 get_new_dir <- function(
-  dir
-) {
+  dir) {
   dir_created <- tryCatch(
     create_if_needed(
       dir,
@@ -598,7 +621,8 @@ check_url_valid <- function(
     msg <- paste0(
       "File not added (URL must end with .",
       type,
-      " extension)")
+      " extension)"
+    )
     cat_red_bullet(
       msg
     )

--- a/R/use_files.R
+++ b/R/use_files.R
@@ -241,24 +241,25 @@ use_external_file <- function(
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
-  dir_created <- tryCatch(
-    create_if_needed(
-      dir,
-      type = "directory"
-    ),
-    error = function(e) {
-      out <- FALSE
-      names(out) <- e[[1]]
-      return(out)
-    }
-  )
+  name <- get_new_name(name)
+  # previously
+  # check_name_length(name)
+  # if (missing(name)) {
+  #   name <- basename(url)
+  # }
 
-  if (isFALSE(dir_created)) {
-    cat_dir_necessary()
-    return(invisible(FALSE))
-  }
-
-  dir <- fs_path_abs(dir)
+  dir <- get_new_dir(dir)
+  if (isFALSE(dir)) return(invisible(FALSE))
+  # previously:
+  # dir_created <- create_if_needed(
+  #   dir,
+  #   type = "directory"
+  # )
+  # if (!dir_created) {
+  #   cat_dir_necessary()
+  #   return(invisible(FALSE))
+  # }
+  # dir <- fs_path_abs(dir)
 
   where <- fs_path(
     dir,

--- a/R/use_files.R
+++ b/R/use_files.R
@@ -29,7 +29,7 @@ use_external_js_file <- function(
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
-  name <- get_new_name(name)
+  name <- get_new_name(name, url)
 
   new_file <- get_new_file(
     name,
@@ -87,7 +87,7 @@ use_external_css_file <- function(
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
-  name <- get_new_name(name)
+  name <- get_new_name(name, url)
 
   new_file <- get_new_file(
     name,
@@ -145,11 +145,11 @@ use_external_html_template <- function(
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
-  name <- get_new_name(name)
+  name <- get_new_name(name, url)
 
   new_file <- get_new_file(
     name,
-    type = "css"
+    type = "html"
   )
 
   dir <- get_new_dir(dir)
@@ -195,7 +195,7 @@ use_external_file <- function(
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
-  name <- get_new_name(name)
+  name <- get_new_name(name, url)
 
   dir <- get_new_dir(dir)
   if (isFALSE(dir)) {
@@ -483,8 +483,9 @@ use_internal_file <- function(
   cat_copied(where)
 }
 get_new_name <- function(
-  name) {
-  if (missing(name)) {
+  name,
+  url) {
+  if (missing(name) || is.null(name)) {
     name <- basename(url)
   }
   check_name_length_is_one(name)

--- a/R/use_files.R
+++ b/R/use_files.R
@@ -88,50 +88,26 @@ use_external_css_file <- function(
   on.exit(setwd(old))
 
   name <- get_new_name(name)
-  # previously:
-  # check_name_length(name)
-  # name <- file_path_sans_ext(name)
-  # if (missing(name)) {
-  #   name <- basename(url)
-  # }
 
   new_file <- get_new_file(
     name,
     type = "css"
   )
-  # previously
-  # new_file <- sprintf("%s.css", name)
 
   dir <- get_new_dir(dir)
   if (isFALSE(dir)) {
     return(invisible(FALSE))
   }
-  # previously
-  # dir_created <- create_if_needed(
-  #   dir,
-  #   type = "directory"
-  # )
-  # if (!dir_created) {
-  #   cat_dir_necessary()
-  #   return(invisible(FALSE))
-  # }
-  # dir <- fs_path_abs(dir)
 
   where <- fs_path(
     dir,
     new_file
   )
-  # no change to previous version
 
   check_file <- check_file_exists(where, overwrite)
   if (isFALSE(check_file)) {
     return(invisible(FALSE))
   }
-  # previously
-  # if (fs_file_exists(where)) {
-  #   cat_exists(where)
-  #   return(invisible(FALSE))
-  # }
 
   check_url <- check_url_valid(
     url,
@@ -140,13 +116,6 @@ use_external_css_file <- function(
   if (isFALSE(check_url)) {
     return(invisible(FALSE))
   }
-  # previously:
-  # if (file_ext(url) != "css") {
-  #   cat_red_bullet(
-  #     "File not added (URL must end with .css extension)"
-  #   )
-  #   return(invisible(FALSE))
-  # }
 
   download_external(url, where)
 
@@ -177,64 +146,28 @@ use_external_html_template <- function(
   on.exit(setwd(old))
 
   name <- get_new_name(name)
-  # previously:
-  # check_name_length(name)
-  # name <- file_path_sans_ext(name)
-  # if (missing(name)) {
-  #   name <- basename(url)
-  # }
 
   new_file <- get_new_file(
     name,
     type = "css"
   )
-  # previously
-  # new_file <- sprintf("%s.css", name)
 
   dir <- get_new_dir(dir)
   if (isFALSE(dir)) {
     return(invisible(FALSE))
   }
-  # previously
-  # dir_created <- create_if_needed(
-  #   dir,
-  #   type = "directory"
-  # )
-  # if (!dir_created) {
-  #   cat_dir_necessary()
-  #   return(invisible(FALSE))
-  # }
-  # dir <- fs_path_abs(dir)
+
   where <- fs_path(
     dir,
     new_file
   )
-  # no change to previous version
 
   check_file <- check_file_exists(where, overwrite)
   if (isFALSE(check_file)) {
     return(invisible(FALSE))
   }
-  # previously
-  # if (fs_file_exists(where)) {
-  #   cat_exists(where)
-  #   return(invisible(FALSE))
-  # }
-
-  # MAYBE? -> add possible url-check for html-type files
-  # check_url <- check_url_valid(
-  #   url,
-  #   type = "html")
-  # if (isFALSE(check_url)) return(invisible(FALSE))
 
   download_external(url, where)
-  # previously
-  # cat_start_download()
-  # utils::download.file(url, where)
-
-  # remove:
-  # cat_downloaded(where)
-  # and add to catfun inside file_created_dance() see below
 
   file_created_dance(
     where,
@@ -263,26 +196,11 @@ use_external_file <- function(
   on.exit(setwd(old))
 
   name <- get_new_name(name)
-  # previously
-  # check_name_length(name)
-  # if (missing(name)) {
-  #   name <- basename(url)
-  # }
 
   dir <- get_new_dir(dir)
   if (isFALSE(dir)) {
     return(invisible(FALSE))
   }
-  # previously:
-  # dir_created <- create_if_needed(
-  #   dir,
-  #   type = "directory"
-  # )
-  # if (!dir_created) {
-  #   cat_dir_necessary()
-  #   return(invisible(FALSE))
-  # }
-  # dir <- fs_path_abs(dir)
 
   where <- fs_path(
     dir,
@@ -293,12 +211,6 @@ use_external_file <- function(
   if (isFALSE(check_file)) {
     return(invisible(FALSE))
   }
-  # previously
-  # if (fs_file_exists(where)) {
-  #   cat_exists(where)
-  #   return(invisible(FALSE))
-  # }
-  # cat_start_download()
 
   utils::download.file(url, where)
 

--- a/man/use_files.Rd
+++ b/man/use_files.Rd
@@ -17,7 +17,8 @@ use_external_js_file(
   pkg = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
-  dir_create = TRUE
+  dir_create = TRUE,
+  overwrite = FALSE
 )
 
 use_external_css_file(
@@ -26,7 +27,8 @@ use_external_css_file(
   pkg = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
-  dir_create = TRUE
+  dir_create = TRUE,
+  overwrite = FALSE
 )
 
 use_external_html_template(
@@ -35,7 +37,8 @@ use_external_html_template(
   pkg = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
-  dir_create = TRUE
+  dir_create = TRUE,
+  overwrite = FALSE
 )
 
 use_external_file(
@@ -44,7 +47,8 @@ use_external_file(
   pkg = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
-  dir_create = TRUE
+  dir_create = TRUE,
+  overwrite = FALSE
 )
 
 use_internal_js_file(
@@ -95,6 +99,8 @@ use_internal_file(
 \item{open}{Should the created file be opened?}
 
 \item{dir_create}{Creates the directory if it doesn't exist, default is \code{TRUE}.}
+
+\item{overwrite}{logical; if \code{TRUE}, then external file is overwritten}
 
 \item{path}{String representation of the local path for the file to be implemented (use_file only)}
 }

--- a/tests/testthat/test-use_files.R
+++ b/tests/testthat/test-use_files.R
@@ -13,7 +13,7 @@ test_that("use_external_XXX_files() function family works properly", {
         url = "https://raw.githubusercontent.com/ThinkR-open/golem/dev/inst/utils/testfile_template_plainfile.txt"
       )
       test_file_download <- readLines(
-        "inst/app/www/testfile_template_plainfile.txt"
+        "inst/app/www/testfile_template_plainfile"
       )
       expect_identical(
         test_file_download,


### PR DESCRIPTION
To fix #819 , there is the possibility to refactor the internals of `use_external_XXX` type functions in  `use_files.R ` **_prior to the addition of a new replace arg_**.

This may or may not be useful; I think it could be, hence the draft PR with some benefits being to reduce duplication

It's easier to add the 'replace'-argument in only one place then (see last commit to this PR).

Essentially all `use_external_xxx` funcs in `use_files.R` do the same, so this PR tries to encapsulate identical behaviour into smaller maintainable pieces. 

Of course this proposal comes along with quite some work and probably there should be some tests added as well... happy do get on this though!