### PR TITLE
942 install sass if missing

### DIFF
--- a/R/install_dev_deps.R
+++ b/R/install_dev_deps.R
@@ -47,7 +47,7 @@ install_dev_deps <- function(
     # want to install, which is what they want
     f <- rlang::check_installed
   } else {
-    # Case 2, the user runs this function with force_install to FALSE
+    # Case 2, the user runs this function with force_install to TRUE
     # At that point, the user probably has pak installed
     # If yes, the installation function
     # will be pak::pkg_install, otherwise
@@ -68,6 +68,46 @@ install_dev_deps <- function(
     }
   }
 }
+
+#' Install a single dev-dep
+#'
+#' Work the same way as [install_dev_deps()] when choosing installation
+#'   function.
+#'
+#' @param dev_dep a sing character giving the dependency to install
+#' @inheritParams install_dev_deps
+install_single_dev_dep <- function(
+  dev_dep = NULL,
+  force_install = FALSE,
+  ...) {
+    if (missing(dev_dep)) stop("Must provide arg to 'dev_dep'")
+    if (!is.character(dev_dep)) stop("Arg. 'dev_dep' must be character.")
+
+    # placeholder for 'temp_case'
+    tc <- character(0)
+    # go through cases as the install_dev_deps() function:
+    # case C0: force_install is FALSE and R is in non-interactive mode
+    if (isFALSE(force_install) && isFALSE(interactive())) tc <- "C0"
+    # case C1: force_install is FALSE and R is in interactive mode
+    if (isFALSE(force_install) && isTRUE(interactive())) tc <- "C1"
+    # case C2: force_install is TRUE and we have 'pak'
+    if (isTRUE(force_install) && isTRUE(rlang::is_installed("pak"))) tc <- "C2"
+    # case C3: force_install is TRUE and we do not have 'pak'
+    if (isTRUE(force_install) && isFALSE(rlang::is_installed("pak"))) tc <- "C3"
+
+    f <- switch(
+      tc,
+      C0 = "`install_dev_deps()` will not install dev dependencies in non-interactive mode if `force_install` is not set to `TRUE`.",
+      C1 = rlang::check_installed,
+      C2 = getFromNamespace("pkg_install", "pak"),
+      C3 = utils::install.packages
+    )
+    if (is.character(f)) {
+      warning(f)
+    } else {
+      f(dev_dep)
+    }
+  }
 
 dev_deps <- unique(
   c(

--- a/R/run_dev.R
+++ b/R/run_dev.R
@@ -40,6 +40,9 @@ run_dev <- function(
     )
   }
 
+  check_sass_used <- isTRUE(any(grepl("sass::", run_dev_lines)))
+  if (check_sass_used) install_single_dev_dep("sass")
+
   eval(
     parse(
       text = run_dev_lines


### PR DESCRIPTION
This PR fixes #942 

BUG: whenever a line with "sass::sass" is added to `dev/run_dev.R` (via `add_sass_file()`) and `run_dev()` is called, there is a missing sass-package error.

Fix: `install_single_dev_dep()`, a newly added helper, is invoked to install the dependency "sass" (when missing). The user interaction follows the same pattern as `install_dev_deps()`. 



