### PR TITLE
805 set golem name inside ./tests and ./vignettes

### DIFF
--- a/R/golem-yaml-set.R
+++ b/R/golem-yaml-set.R
@@ -33,6 +33,7 @@ set_golem_name <- function(
   pkg = golem::pkg_path(),
   talkative = TRUE
 ) {
+  old_name <- golem::pkg_name()
   path <- fs_path_abs(pkg)
 
   # Changing in YAML
@@ -63,7 +64,33 @@ set_golem_name <- function(
     file = "DESCRIPTION"
   )
 
+  # Changing in ./tests/ if dir present
+  set_golem_name_tests(
+    old_name = old_name,
+    new_name = name
+  )
+
   invisible(name)
+}
+
+set_golem_name_tests <- function(
+  old_name,
+  new_name
+) {
+  pth_dir_tests <- file.path(
+    get_golem_wd(),
+    "tests")
+
+  check_dir_tests <- fs_dir_exists(pth_dir_tests)
+
+  if (check_dir_tests) {
+    pth_testthat_r <- file.path(pth_dir_tests, "testthat.R")
+    old_testthat_r <- readLines(pth_testthat_r)
+    new_testthat_r <- gsub(old_name, new_name, old_testthat_r)
+    writeLines(new_testthat_r, pth_testthat_r)
+  }
+
+  return(invisible(old_name))
 }
 
 #' @export

--- a/R/golem-yaml-set.R
+++ b/R/golem-yaml-set.R
@@ -70,6 +70,12 @@ set_golem_name <- function(
     new_name = name
   )
 
+  # Changing in ./vignettes/ if dir present
+  set_golem_name_vignettes(
+    old_name = old_name,
+    new_name = name
+  )
+
   invisible(name)
 }
 
@@ -88,6 +94,35 @@ set_golem_name_tests <- function(
     old_testthat_r <- readLines(pth_testthat_r)
     new_testthat_r <- gsub(old_name, new_name, old_testthat_r)
     writeLines(new_testthat_r, pth_testthat_r)
+  }
+
+  return(invisible(old_name))
+}
+
+set_golem_name_vignettes <- function(
+  old_name,
+  new_name
+) {
+  pth_dir_vignettes <- file.path(
+    get_golem_wd(),
+    "vignettes")
+
+  check_dir_vignettes <- fs_dir_exists(pth_dir_vignettes)
+
+  if (check_dir_vignettes) {
+    pth_vignette_old <- file.path(
+      pth_dir_vignettes,
+      paste0(old_name, ".Rmd")
+    )
+    old_vignette_r <- readLines(pth_vignette_old)
+    new_vignette_r <- gsub(old_name, new_name, old_vignette_r)
+
+    pth_vignette_new <- file.path(
+      pth_dir_vignettes,
+      paste0(new_name, ".Rmd")
+    )
+    writeLines(new_vignette_r, pth_vignette_new)
+    file.remove(pth_vignette_old)
   }
 
   return(invisible(old_name))


### PR DESCRIPTION
Fix #805 by applying changes to golem-name in `./tests` and `./vignettes` when these dirs are present (i.e. whenever tests or vignettes are there).

Done:
- fix bug for `./tests`
- fix bug for `./vignettes`

To-Do:
- ~~fix bug for `./vignettes`~~
- handle the content of `./doc`

@ColinFay @ArthurData : what about `./doc` content whch arises after the `devtools::build_vignettes()` command is used? There are `old_name.{html,R,Rmd}` artefacts ... at least three solutions come to my mind:

1. delete content `./doc` and rebuild (is this what the user wants after having just executed `golem::set_golem_name()`?)
2. rename files and their content (this can break or cause issues in the future as some things may not be adequately handled by naive `gsub`+`read/writeLines` hacking)
3. prompt a warning, expecting the user to handle `./doc` (i.e. delete old files and rebuild); `devtools::check()` passes irrespective of the content of `./doc`

Or a combination of 1+3 vs. 1+2. 
