### PR TITLE
fix: better checks for add_module

### DIFF
--- a/R/add_r_files.R
+++ b/R/add_r_files.R
@@ -30,14 +30,18 @@ add_r_files <- function(
     # Remove the "mod_" if any
     module <- mod_remove(module)
     if (!is_existing_module(module)) {
-      stop(
-        sprintf(
-          "The module '%s' does not exist.\nYou can call `golem::add_module('%s')` to create it.",
-          module,
-          module
-        ),
-        call. = FALSE
-      )
+      # Check for esoteric 'mod_mod_' module names and if that fails throw error
+      if (!is_existing_module(paste0("mod_", module))) {
+        stop(
+          sprintf(
+            "The module '%s' does not exist.\nYou can call `golem::add_module('%s')` to create it.",
+            module,
+            module
+          ),
+          call. = FALSE
+        )
+      }
+      module <- paste0("mod_", module)
     }
     module <- paste0("mod_", module, "_")
   }

--- a/R/boostrap_cli.R
+++ b/R/boostrap_cli.R
@@ -33,3 +33,13 @@ cli_cat_rule <- function(...) {
     )
   })
 }
+
+cli_cli_alert_info <- function(...) {
+  check_cli_installed()
+
+  do_if_unquiet({
+    cli::cli_alert_info(
+      ...
+    )
+  })
+}

--- a/R/modules_fn.R
+++ b/R/modules_fn.R
@@ -40,6 +40,7 @@ add_module <- function(
 ) {
   check_name_length(name)
   name <- file_path_sans_ext(name)
+  name <- check_name_syntax(name)
 
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))

--- a/R/modules_fn.R
+++ b/R/modules_fn.R
@@ -37,14 +37,24 @@ add_module <- function(
   module_template = golem::module_template,
   with_test = FALSE,
   ...
-) {
+    ) {
+  # Let's start with the checks for the validity of the name
   check_name_length(name)
-  name <- file_path_sans_ext(name)
-  name <- check_name_syntax(name)
+  check_name_syntax(name)
 
+  # We now check that:
+  # - The file name has no "mod_" prefix
+  # - The file name has no extension
+  name <- mod_remove(
+    file_path_sans_ext(name)
+  )
+
+  # Performing the creation inside the pkg root
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
+  # The module creation only works if the R folder
+  # is there
   dir_created <- create_if_needed(
     fs_path(pkg, "R"),
     type = "directory"
@@ -55,17 +65,23 @@ add_module <- function(
     return(invisible(FALSE))
   }
 
+  # Now we build the correct module file name
   where <- fs_path(
     "R",
     paste0("mod_", name, ".R")
   )
 
+  # If the file doesn't exist, we create it
   if (!fs_file_exists(where)) {
     fs_file_create(where)
 
-    module_template(name = name, path = where, export = export, ...)
+    module_template(
+      name = name,
+      path = where,
+      export = export,
+      ...
+    )
 
-    # write_there(" ")
     cat_created(where)
     open_or_go_to(where, open)
   } else {
@@ -75,20 +91,38 @@ add_module <- function(
     )
   }
 
+  # Creating all the files that come with the module
   if (!is.null(fct)) {
-    add_fct(fct, module = name, open = open)
+    add_fct(
+      fct,
+      module = name,
+      open = open
+    )
   }
 
   if (!is.null(utils)) {
-    add_utils(utils, module = name, open = open)
+    add_utils(
+      utils,
+      module =
+        name,
+      open = open
+    )
   }
 
   if (!is.null(js)) {
-    add_js_file(js, pkg = pkg, open = open)
+    add_js_file(
+      js,
+      pkg = pkg,
+      open = open
+    )
   }
 
   if (!is.null(js_handler)) {
-    add_js_handler(js_handler, pkg = pkg, open = open)
+    add_js_handler(
+      js_handler,
+      pkg = pkg,
+      open = open
+    )
   }
 
   if (with_test) {
@@ -153,7 +187,7 @@ module_template <- function(
   ph_ui = " ",
   ph_server = " ",
   ...
-) {
+    ) {
   write_there <- function(...) {
     write(..., file = path, append = TRUE)
   }
@@ -237,7 +271,7 @@ use_module_test <- function(
   name,
   pkg = get_golem_wd(),
   open = TRUE
-) {
+    ) {
   # Remove the extension if any
   name <- file_path_sans_ext(name)
   # Remove the "mod_" if any
@@ -339,9 +373,14 @@ use_module_test <- function(
 }
 
 mod_remove <- function(string) {
-  gsub(
-    "^mod_",
-    "",
-    string
-  )
+  while (
+    grepl("^mod_", string)
+  ) {
+    string <- gsub(
+      "^mod_",
+      "",
+      string
+    )
+  }
+  string
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -508,3 +508,31 @@ do_if_unquiet <- function(expr) {
     force(expr)
   }
 }
+
+# This functions checks that the 'name' argument
+# of add_module() does not start with 'mod_' as
+# this is prepended by add_module() per default.
+check_name_syntax <- function(name) {
+  check_mod <- grepl("^mod_", name)
+  name_proposed <- gsub("^mod_", "", name)
+  if (isTRUE(check_mod)) {
+    msg <- paste0(
+      "Argument 'name' starts with 'mod_' but {golem} prepends 'mod_' to your",
+      " module name automatically.\nDo you want to name your module: "
+    )
+    cat(msg)
+    ask <- menu(paste0("'mod_", c(name_proposed, name), "'?"))
+    if (ask == 1) {
+      return(name_proposed)
+    } else if (ask == 2) {
+      # optional
+      # message("Keeping name: '", name, "' as module name.")
+      return(name)
+    } else {
+      warning("Could not check name syntax properly ...")
+      return(invisible(name))
+    }
+  } else {
+    return(name)
+  }
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -513,26 +513,12 @@ do_if_unquiet <- function(expr) {
 # of add_module() does not start with 'mod_' as
 # this is prepended by add_module() per default.
 check_name_syntax <- function(name) {
-  check_mod <- grepl("^mod_", name)
-  name_proposed <- gsub("^mod_", "", name)
-  if (isTRUE(check_mod)) {
-    msg <- paste0(
-      "Argument 'name' starts with 'mod_' but {golem} prepends 'mod_' to your",
-      " module name automatically.\nDo you want to name your module: "
+  if (isTRUE(grepl("^mod_", name))) {
+    cli_cli_alert_info(
+      "You set a 'name' that starts with 'mod_'."
     )
-    cat(msg)
-    ask <- menu(paste0("'mod_", c(name_proposed, name), "'?"))
-    if (ask == 1) {
-      return(name_proposed)
-    } else if (ask == 2) {
-      # optional
-      # message("Keeping name: '", name, "' as module name.")
-      return(name)
-    } else {
-      warning("Could not check name syntax properly ...")
-      return(invisible(name))
-    }
-  } else {
-    return(name)
+    cli_cli_alert_info(
+      "This is not necessary as golem will prepend 'mod_' to your module name automatically."
+    )
   }
 }

--- a/tests/testthat/test-add_modules.R
+++ b/tests/testthat/test-add_modules.R
@@ -49,5 +49,20 @@ test_that("add_module", {
     remove_file("R/mod_test2.R")
     remove_file("R/mod_test2_fct_ftest.R")
     remove_file("R/mod_test2_utils_utest.R")
+
+    # Checking that the mod_ prefix is removed and added
+    add_module(
+      "mod_mod_mod_test2.R",
+      open = FALSE,
+      pkg = pkg,
+      fct = "ftest",
+      utils = "utest"
+    )
+    expect_true(file.exists("R/mod_test2.R"))
+    expect_true(file.exists("R/mod_test2_fct_ftest.R"))
+    expect_true(file.exists("R/mod_test2_utils_utest.R"))
+    remove_file("R/mod_test2.R")
+    remove_file("R/mod_test2_fct_ftest.R")
+    remove_file("R/mod_test2_utils_utest.R")
   })
 })


### PR DESCRIPTION
1. add a double check to look for modules with names starting with "mod_mod_xxx" 

2. add syntax check for module names to add_module(): explicitly inform the user that they don't need to add mod_ to the name. 

Implementation and bug report by @ilyaZar 