### PR TITLE
878 merge fill_desc and set_options

### DIFF
--- a/R/desc.R
+++ b/R/desc.R
@@ -15,11 +15,9 @@
 #' @param author_email  to be deprecated: use character for first name via
 #'    \code{authors = person(email = "author_email")} instead
 #' @param author_orcid  to be deprecated
-#' @param set_options logical; if \code{TRUE} then [set_golem_options()] is run
-#'    which will be the default behaviour in the next version. Current default
-#'    is \code{FALSE} though; so run [set_golem_options()] manually when
-#'    necessary.
-#'
+#' @param set_options logical; if \code{TRUE} then [set_golem_options()] is run,
+#'    which is the default; if \code{FALSE} then running [set_golem_options()]
+#'    manually at some point is strongly recommended
 #'
 #' @export
 #' @importFrom utils person
@@ -43,7 +41,7 @@ fill_desc <- function(
   author_last_name = NULL,
   author_email = NULL,
   author_orcid = NULL,
-  set_options = FALSE
+  set_options = TRUE
 ) {
 
   stopifnot(`'authors' must be of class 'person'` = inherits(authors, "person"))

--- a/R/desc.R
+++ b/R/desc.R
@@ -15,6 +15,11 @@
 #' @param author_email  to be deprecated: use character for first name via
 #'    \code{authors = person(email = "author_email")} instead
 #' @param author_orcid  to be deprecated
+#' @param set_options logical; if \code{TRUE} then [set_golem_options()] is run
+#'    which will be the default behaviour in the next version. Current default
+#'    is \code{FALSE} though; so run [set_golem_options()] manually when
+#'    necessary.
+#'
 #'
 #' @export
 #' @importFrom utils person
@@ -37,7 +42,8 @@ fill_desc <- function(
   author_first_name = NULL,
   author_last_name = NULL,
   author_email = NULL,
-  author_orcid = NULL
+  author_orcid = NULL,
+  set_options = FALSE
 ) {
 
   stopifnot(`'authors' must be of class 'person'` = inherits(authors, "person"))
@@ -140,6 +146,9 @@ fill_desc <- function(
     bullet = "tick",
     bullet_col = "green"
   )
+
+  if (isTRUE(set_options)) set_golem_options()
+
   return(
     invisible(
       desc

--- a/inst/mantests/build.R
+++ b/inst/mantests/build.R
@@ -225,7 +225,6 @@ cat_ok()
 
 cli::cat_rule("set_golem_options")
 
-golem::set_golem_options()
 expect_equal(
   golem::get_golem_wd(),
   golem::pkg_path()

--- a/inst/shinyexample/dev/01_start.R
+++ b/inst/shinyexample/dev/01_start.R
@@ -26,7 +26,7 @@ golem::fill_desc(
     given = "AUTHOR_FIRST", # Your First Name
     family = "AUTHOR_LAST", # Your Last Name
     email = "AUTHOR@MAIL.COM", # Your email
-    role = c("aut", "cre")
+    role = c("aut", "cre") # Your role (here author/creator)
   ),
   repo_url = NULL, # The URL of the GitHub repo (optional),
   pkg_version = "0.0.0.9000", # The version of the package containing the app

--- a/inst/shinyexample/dev/01_start.R
+++ b/inst/shinyexample/dev/01_start.R
@@ -31,7 +31,6 @@ golem::fill_desc(
   repo_url = NULL, # The URL of the GitHub repo (optional),
   pkg_version = "0.0.0.9000", # The version of the package containing the app
   set_options = FALSE # do not automatically run set_golem_options() but will
-  # change to TRUE in the future, see below
 )
 
 ## Set {golem} options ----

--- a/inst/shinyexample/dev/01_start.R
+++ b/inst/shinyexample/dev/01_start.R
@@ -29,10 +29,14 @@ golem::fill_desc(
     role = c("aut", "cre")
   ),
   repo_url = NULL, # The URL of the GitHub repo (optional),
-  pkg_version = "0.0.0.9000" # The version of the package containing the app
+  pkg_version = "0.0.0.9000", # The version of the package containing the app
+  set_options = FALSE # do not automatically run set_golem_options() but will
+  # change to TRUE in the future, see below
 )
 
 ## Set {golem} options ----
+## Is highly recommended to run and will be set as the default via
+## fill_desc(..., set_options = TRUE) in future versions of {golem}
 golem::set_golem_options()
 
 ## Install the required dev dependencies ----

--- a/inst/shinyexample/dev/01_start.R
+++ b/inst/shinyexample/dev/01_start.R
@@ -30,7 +30,7 @@ golem::fill_desc(
   ),
   repo_url = NULL, # The URL of the GitHub repo (optional),
   pkg_version = "0.0.0.9000", # The version of the package containing the app
-  set_options = FALSE # do not automatically run set_golem_options() but will
+  set_options = TRUE # Set the global golem options
 )
 
 ## Set {golem} options ----

--- a/vignettes/a_start.Rmd
+++ b/vignettes/a_start.Rmd
@@ -123,7 +123,9 @@ golem::fill_desc(
     role = c("aut", "cre")
     ),
   repo_url = NULL, # The URL of the GitHub repo (optional),
-  pkg_version = "0.0.0.9000" # The version of the package containing the app
+  pkg_version = "0.0.0.9000", # The version of the package containing the app,
+  set_options = FALSE # do not automatically run set_golem_options() but will
+  # change to TRUE in the future, see below
 )
 ```
 
@@ -131,7 +133,8 @@ About [the DESCRIPTION file](https://r-pkgs.org/description.html).
 
 ### Add `{golem}` options
 
-Please DO run this line of code, as it sets a series of global options inside `golem-config.yml` that will be reused inside `{golem}`.
+Please DO run this line of code, as it sets a series of global options inside `golem-config.yml` that will be reused inside `{golem}`. It will be set as the default via above fill_desc(..., set_options = TRUE) in future versions of
+{golem}.
 
 ```{r}
 golem::set_golem_options()

--- a/vignettes/a_start.Rmd
+++ b/vignettes/a_start.Rmd
@@ -125,7 +125,6 @@ golem::fill_desc(
   repo_url = NULL, # The URL of the GitHub repo (optional),
   pkg_version = "0.0.0.9000", # The version of the package containing the app,
   set_options = FALSE # do not automatically run set_golem_options() but will
-  # change to TRUE in the future, see below
 )
 ```
 

--- a/vignettes/a_start.Rmd
+++ b/vignettes/a_start.Rmd
@@ -124,7 +124,7 @@ golem::fill_desc(
     ),
   repo_url = NULL, # The URL of the GitHub repo (optional),
   pkg_version = "0.0.0.9000", # The version of the package containing the app,
-  set_options = FALSE # do not automatically run set_golem_options() but will
+  set_options = TRUE # Set the global golem options
 )
 ```
 

--- a/vignettes/a_start.Rmd
+++ b/vignettes/a_start.Rmd
@@ -120,7 +120,7 @@ golem::fill_desc(
     given = "AUTHOR_FIRST", # Your First Name
     family = "AUTHOR_LAST", # Your Last Name
     email = "AUTHOR@MAIL.COM", # Your email
-    role = c("aut", "cre")
+    role = c("aut", "cre") # Your role (here author/creator)
     ),
   repo_url = NULL, # The URL of the GitHub repo (optional),
   pkg_version = "0.0.0.9000", # The version of the package containing the app,


### PR DESCRIPTION
Fix #878.

Not sure (since it's been a while ..) if it is  __*still*__ planned to be a breaking change as mentioned in https://github.com/ThinkR-open/golem/issues/878#issuecomment-1212434319 .

It need not be a breaking change __*for the moment*__ so here is a "careful" version with a deprecation note for the user in the docs:

1. Add a new parameter `set_options = FALSE` to `fill_desc()`, so  `set_golem_options()` will not run per default. However, `set_golem_options()` is run when that flag is `TRUE` (see commit 1 to this PR).

2. That default `FALSE` is set inside files 01_start.R and a_start.Rmd for the user, adding a comment about future deprecation (see commit 2 to this PR).

3. For testing purposes one can `set_options = TRUE` in “build.R” (commit 3 to this PR) for some time.



