### PR TITLE
Fix 887 and improve code coverage of `R/config.R` from  28.21% to 100%

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,7 @@ Suggests:
     testthat,
     tools,
     withr,
+    mockery,
     attachment (>= 0.2.5),
     renv,
     usethis (>= 1.6.0),

--- a/R/config.R
+++ b/R/config.R
@@ -85,7 +85,7 @@ try_user_config_location <- function(pth) {
   out_config_char <- substring(out_config_char, 2, nchar(out_config_char) - 1)
 
   # V. return full path to new config file including pkg-path and 'inst'
-  return(file.path(pth, "inst", out_config_char))
+  return(fs_path(pth, "inst", out_config_char))
 }
 guess_lines_to_config_file <- function(guess_text) {
   # I. Check if the path is a one-liner i.e. try to match `app_sys(...)` string
@@ -104,7 +104,7 @@ guess_lines_to_config_file <- function(guess_text) {
       from = tmp_guess_lines + 1,
       to = length(guess_text)
     )
-    # Fine the closing brace `)` of app_sys(...) - identified code portion must
+    # Find the closing brace `)` of app_sys(...) - identified code portion must
     # contain information on the path.
     tmp_end_line <- NULL
     for (i in tmp_check_lines) {

--- a/R/config.R
+++ b/R/config.R
@@ -41,7 +41,7 @@ guess_where_config <- function(
   })
 
   if (
-    !is_try_error(ret_path) &
+    !is_try_error(ret_path) &&
       fs_file_exists(ret_path)
   ) {
     return(

--- a/R/config.R
+++ b/R/config.R
@@ -68,7 +68,10 @@ guess_where_config <- function(
   if (fs_file_exists(ret_pth)) {
     return(fs_path_abs(ret_pth))
   }
-  # IV.B Trying with pkg_path
+  # IV.B Try with pkg_path() and default filename in case function arguments
+  # 'path' and 'file' are not working (though it's unusual to set values for
+  # this arguments to something different from the defaults we still want to
+  # cover this case)
   ret_pth <- attempt({
     fs_path(
       golem::pkg_path(),
@@ -78,9 +81,7 @@ guess_where_config <- function(
   if (!is_try_error(ret_pth) && fs_file_exists(ret_pth)) {
     return(fs_path_abs(ret_pth))
   }
-  if (fs_file_exists(ret_pth)) {
-    return(fs_path_abs(ret_pth))
-  }
+
   # If all cases fail return NULL
   return(NULL)
 }

--- a/R/config.R
+++ b/R/config.R
@@ -25,6 +25,7 @@ guess_where_config <- function(
   CONFIG_DFLT_MISSNG <- !CONFIG_DFLT_EXISTS
   CONFIG_USER_EXISTS <- !is.null(ret_pth_usr) && (!identical(ret_pth_usr, ret_pth_def))
   CONFIG_USER_MISSNG <- !CONFIG_USER_EXISTS
+
   # Case I.
   # The default config exists AND "R/app_config.R" does not provide any
   # information about a possible user config (this one should be correct in 99%
@@ -33,6 +34,7 @@ guess_where_config <- function(
   if (CONFIG_DFLT_EXISTS && CONFIG_USER_MISSNG) {
     return(fs_path_abs(ret_pth_def))
   }
+
   # Case II.
   # The default config does not exists AND "R/app_config.R" provides information
   # about a possible user config (this one should be correct if the user changed
@@ -43,6 +45,7 @@ guess_where_config <- function(
   if (CONFIG_DFLT_MISSNG && CONFIG_USER_EXISTS) {
     return(fs_path_abs(ret_pth_usr))
   }
+
   # Case III.
   # The default config does exists AND "R/app_config.R" provides information
   # about a possible user config which is found! (this occurs if the user
@@ -171,17 +174,10 @@ get_current_config <- function(path = getwd()) {
   }
 
   if (!fs_file_exists(path_conf)) {
-    if (interactive()) {
-      ask <- yesno(
-        sprintf(
-          "The %s file doesn't exist.\nIt's possible that you might not be in a {golem} based project.\n Do you want to create the {golem} files?",
-          basename(path_conf)
-        )
-      )
+    if (rlang::is_interactive()) {
+      ask <- ask_golem_creation_upon_config(path_conf)
       # Return early if the user doesn't allow
-      if (!ask) {
-        return(NULL)
-      }
+      if (!ask) return(NULL)
 
       fs_file_copy(
         path = golem_sys("shinyexample/inst/golem-config.yml"),
@@ -221,6 +217,13 @@ get_current_config <- function(path = getwd()) {
   )
 }
 
+ask_golem_creation_upon_config <- function(pth) {
+  msg <- paste0(
+    "The %s file doesn't exist.",
+    "\nIt's possible that you might not be in a {golem} based project.\n",
+    "Do you want to create the {golem} files?")
+  yesno(sprintf(msg, basename(pth)))
+}
 # This function changes the name of the
 # package in app_config when you need to
 # set the {golem} name

--- a/R/config.R
+++ b/R/config.R
@@ -152,13 +152,50 @@ guess_lines_to_config_file <- function(guess_text) {
   }
   return(tmp_guess_lines)
 }
-#' Get the path to the current config File
+#' Return path to the `{golem}` config-file
 #'
-#' This function tries to guess where the golem-config file is located.
-#' If it can't find it, this function asks the
-#' user if they want to set the golem skeleton.
+#' This function tries to find the path to the `{golem}` config-file currently
+#' used. If the config-file is not found, the user is asked if they want to set parts
+#' of the `{golem}` skeleton. This includes default versions of "R/app_config"
+#' and "inst/golem-config.yml" (assuming that the user tries to convert the
+#' directory to a `{golem}` based shiny App).
 #'
-#' @param path Path to start looking for the config
+#' In most cases this function simply returns the path to the default
+#' golem-config file located under "inst/golem-config.yml". That config comes
+#' in `yml`-format, see the [Engineering Production-Grade Shiny Apps](https://engineering-shiny.org/golem.html?q=config#golem-config)
+#' for further details on its format and how to set options therein.
+#'
+#' Advanced app developers may benefit from having an additional user
+#' config-file. This is achieved by copying the file to the new location and
+#' setting a new path pointing to this file. The path is altered inside the
+#' `app_sys()`-call of the file "R/app_config.R" to point to the (relative to
+#' `inst/`) location of the user-config i.e. change
+#'
+#' ```
+#' # Modify this if your config file is somewhere else
+#' file = app_sys("golem-config.yml")
+#' ```
+#'
+#' to
+#' ```
+#' # Modify this if your config file is somewhere else
+#' file = app_sys("configs/user-golem-config.yml")
+#' ```
+#'
+#' __NOTE__
+#' + the path to the config is changed relative to __*inst/*__ from
+#' __*inst/golem-config.yml*__ to __*inst/configs/user-golem-config.yml*__
+#' + if both, the default config __*and*__ user config files exists (and the
+#' path is set correctly for the latter), an error is thrown due to ambiguity:
+#' in this case simply rename/delete the default config or change the entry in
+#' "R/app_config.R" back to `app_sys("golem-config.yml")` to point to the
+#' default location
+#'
+#'
+#' @param path character string giving the path to start looking for the config;
+#'    the usual value is the `{golem}`-package top-level directory but a user
+#'    supplied config is now supported (see __Details__ for how to use this
+#'    feature).
 #'
 #' @export
 get_current_config <- function(path = getwd()) {

--- a/R/config.R
+++ b/R/config.R
@@ -12,48 +12,76 @@ guess_where_config <- function(
   path = golem::pkg_path(),
   file = "inst/golem-config.yml"
     ) {
-  # We'll try to guess where the path
-  # to the golem-config file is
+  # We'll try to guess where the path to the golem-config file is. Since the
+  # user can now supply a user-defined golem-config there may be several cases
+  # to consider:
 
-  # This one should be correct in 99% of the case
-  # If we don't change the default values of the params.
-  # => current directory /inst/golem-config.yml
-  ret_path <- fs_path(
-    path,
-    file
-  )
-  if (fs_file_exists(ret_path)) {
-    return(fs_path_abs(ret_path))
+  # 0. Firstly:
+  # Read from default and possible user specified locations:
+  ret_pth_def <- fs_path(path, file)
+  ret_pth_usr <- try_user_config_location(pth = path)
+  # Define booleans for different cases
+  CONFIG_DFLT_EXISTS <- fs_file_exists(ret_pth_def)
+  CONFIG_DFLT_MISSNG <- !CONFIG_DFLT_EXISTS
+  CONFIG_USER_EXISTS <- !is.null(ret_pth_usr) && (!identical(ret_pth_usr, ret_pth_def))
+  CONFIG_USER_MISSNG <- !CONFIG_USER_EXISTS
+  # Case I.
+  # The default config exists AND "R/app_config.R" does not provide any
+  # information about a possible user config (this one should be correct in 99%
+  # of the cases if no changes to the default param values are made).
+  # => read config from "inst/golem-config.yml"
+  if (CONFIG_DFLT_EXISTS && CONFIG_USER_MISSNG) {
+    return(fs_path_abs(ret_pth_def))
+  }
+  # Case II.
+  # The default config does not exists AND "R/app_config.R" provides information
+  # about a possible user config (this one should be correct if the user changed
+  # the location of the golem-config and properly deleted the (default) file in
+  # the  default path "inst/golem-config.yml").
+  # => read path to user-config from argument to the app_sys()-call inside
+  # "R/app_config.R"
+  if (CONFIG_DFLT_MISSNG && CONFIG_USER_EXISTS) {
+    return(fs_path_abs(ret_pth_usr))
+  }
+  # Case III.
+  # The default config does exists AND "R/app_config.R" provides information
+  # about a possible user config which is found! (this occurs if the user
+  # changed the location/name of the golem-config, properly adjusted the
+  # corresponding line in "R/app_config.R" but forgot to delete the (default)
+  # config file in the default path "inst/golem-config.yml").
+  # => Throw error and prompt user to check whether default config or user
+  # config should be used.
+  if (CONFIG_DFLT_EXISTS && CONFIG_USER_EXISTS) {
+    msg_err <- paste0(
+      "It appears that two golem config files exist:\n",
+      "- the default 'inst/golem-config.yml'\n",
+      "- file read from an app_sys()-call in 'R/app_config.R'\n",
+      "=> Resolve via either of the two options:\n",
+      "1. KEEP USER-FILE: rename/delete default 'inst/golem-config.yml'\n",
+      "2. KEEP DEFAULT: change 'app_sys(...)' to 'app_sys('golem-config.yml')'.")
+    stop(msg_err)
   }
 
-  # Maybe for some reason we are in inst/
-  ret_path <- "golem-config.yml"
-  if (fs_file_exists(ret_path)) {
-    return(fs_path_abs(ret_path))
+  # Case IV. All other "exotic" cases
+  # IV.A Maybe for some reason we are in inst/
+  ret_pth <- "golem-config.yml"
+  if (fs_file_exists(ret_pth)) {
+    return(fs_path_abs(ret_pth))
   }
-
-  # Trying with pkg_path
-  ret_path <- attempt({
+  # IV.B Trying with pkg_path
+  ret_pth <- attempt({
     fs_path(
       golem::pkg_path(),
       "inst/golem-config.yml"
     )
   })
-
-  if (
-    !is_try_error(ret_path) &&
-      fs_file_exists(ret_path)
-  ) {
-    return(
-      fs_path_abs(ret_path)
-    )
+  if (!is_try_error(ret_pth) && fs_file_exists(ret_pth)) {
+    return(fs_path_abs(ret_pth))
   }
-  ret_path <- try_user_config_location(pth = golem::pkg_path())
-  if (is.null(ret_path)) return(NULL)
-  if (fs_file_exists(ret_path)) {
-    return(fs_path_abs(ret_path))
+  if (fs_file_exists(ret_pth)) {
+    return(fs_path_abs(ret_pth))
   }
-
+  # If all cases fail return NULL
   return(NULL)
 }
 try_user_config_location <- function(pth) {
@@ -67,7 +95,9 @@ try_user_config_location <- function(pth) {
   tmp_guess_text <- readLines("R/app_config.R")
   tmp_guess_lines <- guess_lines_to_config_file(tmp_guess_text)
   ## -> early return if malformation i.e. no lines found that match app_sys(...)
-  if (is.null(tmp_guess_lines)) return(NULL)
+  if (is.null(tmp_guess_lines)) {
+    return(NULL)
+  }
 
   # III. Collapse character-text found into a single char from which to retrieve
   #      path! This is important if the path is a (complicated) multi-line path.

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -165,4 +165,54 @@ test_that("golem-config.yml can be renamed and moved to another location", {
   # V.B test that default sub-function fails to return path and gives NULL
   file.remove("R/app_config.R")
   expect_null(try_user_config_location(pkg_path()))
+
+  # Cleanup
+  unlink(path_dummy_golem, TRUE, TRUE)
+})
+
+test_that("golem-config.yml can be retrieved for some exotic corner cases", {
+
+  path_dummy_golem <- tempfile(pattern = "dummygolem")
+  create_golem(
+    path = path_dummy_golem,
+    open = FALSE
+  )
+
+  old_wd <- setwd(path_dummy_golem)
+  on.exit(setwd(old_wd))
+
+  # 0. The default config path is returned
+  expect_equal(
+    guess_where_config(),
+    fs_path_abs(file.path(
+      path_dummy_golem,
+      "inst/golem-config.yml"
+    ))
+  )
+
+  # Test exotic case IV.A - for some reason wd is set to subdir "inst/"
+  # Change dir to subdir "inst"
+  setwd(file.path(getwd(), "inst"))
+  # Test that the default config path is returned
+  expect_equal(
+    guess_where_config(),
+    fs_path_abs(file.path(
+      path_dummy_golem,
+      "inst/golem-config.yml"
+    ))
+  )
+
+  # Test exotic case IV.B - for some reason wd is set to subdir "inst/"
+  # Change dir to golem-pkg toplevel
+  setwd(path_dummy_golem)
+  # The default config path is returned though arguments are non-sense
+  expect_equal(
+    guess_where_config("hi", "there"),
+    fs_path_abs(file.path(
+      path_dummy_golem,
+      "inst/golem-config.yml"
+    ))
+  )
+  # Cleanup
+  unlink(path_dummy_golem, TRUE, TRUE)
 })

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -76,3 +76,71 @@ test_that("config works", {
     )
   })
 })
+test_that("golem-config.yml can be moved to another location", {
+
+  path_dummy_golem <- tempfile(pattern = "dummygolem")
+
+  golem::create_golem(
+    path = path_dummy_golem,
+    open = FALSE
+  )
+
+  old_wd <- setwd(path_dummy_golem)
+  on.exit(setwd(old_wd))
+
+  # The good config path is returned
+  expect_equal(
+    golem:::guess_where_config(),
+    golem:::fs_path_abs(file.path(
+      path_dummy_golem,
+      "inst/golem-config.yml"
+    ))
+  )
+  # document_and_reload does not throw an error
+  expect_error(
+    document_and_reload(),
+    regexp = NA
+  )
+  expect_equal(
+    get_golem_name(),
+    basename(path_dummy_golem)
+  )
+  expect_equal(
+    get_golem_wd(),
+    path_dummy_golem
+  )
+
+  ## Move config file
+  dir.create(
+    "inst/config"
+  )
+  file.copy(
+    from = "inst/golem-config.yml",
+    to = "inst/config/golem.yml"
+  )
+  file.remove(
+    "inst/golem-config.yml"
+  )
+  # User adjusts the correct line in app_config.R:
+  tmp_app_config_r <- readLines("R/app_config.R")
+  tmp_app_config_r[36] <- "  file = app_sys(\"config/golem.yml\")"
+  writeLines(tmp_app_config_r, "R/app_config.R")
+
+  # The good config path is returned
+  expect_equal(
+    golem:::guess_where_config(),
+    golem:::fs_path_abs(file.path(
+      path_dummy_golem,
+      "inst/config/golem.yml"
+    ))
+  )
+  # document_and_reload does not throw an error
+  expect_error(
+    document_and_reload(),
+    regexp = NA
+  )
+  expect_equal(
+    get_golem_name(),
+    basename(path_dummy_golem)
+  )
+})

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -193,7 +193,7 @@ test_that("golem-config.yml can be retrieved for some exotic corner cases", {
     ))
   )
 
-  # Test exotic case IV.B - for some reason wd is set to subdir "inst/"
+  # Test exotic case IV.B - non-sense arguments inside guess_where_config() work
   # Change dir to golem-pkg toplevel
   setwd(path_dummy_golem)
   # The default config path is returned though arguments are non-sense


### PR DESCRIPTION
Fix #887

Problem:
Whenever `golem::document_and_reload()` calls `get_golem_wd()` to retrieve values from a yml-config, _and the user changed the location of that yml before that call_, `golem::document_and_reload()` is not aware of that location change and fails. Specifically, `guess_where_config()` cannot find the location when it is not of standard type (e.g. "inst/golem-config.yml").

Fix:
This PR solves this by adding a helper to `guess_where_config()` which finds the user config-yaml by reading its new location from user changes in "R/app_config.R". 