### PR TITLE
1046 polish docs

### DIFF
--- a/R/desc.R
+++ b/R/desc.R
@@ -1,4 +1,8 @@
-#' Fill your description
+#' Fill your `DESCRIPTION` file
+#'
+#' Generates a standard `DESCRIPTION` file as used in R packages. Also sets
+#' a series of global options inside `golem-config.yml` that will be reused
+#' inside `{golem}` (see `set_options` and [set_golem_options()] for details).
 #'
 #' @param pkg_name The name of the package
 #' @param pkg_title The title of the package
@@ -9,20 +13,20 @@
 #' @param pkg_version The version of the package. Default is 0.0.0.9000
 #' @param pkg Path to look for the DESCRIPTION. Default is `get_golem_wd()`.
 #' @param author_first_name to be deprecated: use character for first name via
-#'    \code{authors = person(given = "authors_first_name")} instead
+#'    `authors = person(given = "authors_first_name")` instead
 #' @param author_last_name  to be deprecated: use character for last name via
-#'    \code{authors = person(given = "authors_last_name")} instead
-#' @param author_email  to be deprecated: use character for first name via
-#'    \code{authors = person(email = "author_email")} instead
-#' @param author_orcid  to be deprecated
-#' @param set_options logical; if \code{TRUE} then [set_golem_options()] is run,
-#'    which is the default; if \code{FALSE} then running [set_golem_options()]
-#'    manually at some point is strongly recommended
+#'    `authors = person(given = "authors_last_name")` instead
+#' @param author_email to be deprecated: use character for first name via
+#'    `authors = person(email = "author_email")` instead
+#' @param author_orcid to be deprecated
+#' @param set_options logical; the default `TRUE` sets all recommended
+#'    options but this can be suppressed with `FALSE`. For details on the
+#'    exact behaviour see the help [set_golem_options()].
 #'
 #' @export
 #' @importFrom utils person
 #'
-#' @return The {desc} object, invisibly.
+#' @return The `{desc}` object, invisibly.
 fill_desc <- function(
   pkg_name,
   pkg_title,
@@ -43,7 +47,7 @@ fill_desc <- function(
   author_orcid = NULL,
   set_options = TRUE
 ) {
-
+  stopifnot(`'set_options' must be logical` = is.logical(set_options))
   stopifnot(`'authors' must be of class 'person'` = inherits(authors, "person"))
 
   # Handling retrocompatibility
@@ -56,7 +60,9 @@ fill_desc <- function(
         author_last_name,
         author_email,
         author_orcid
-      ), is.null, logical(1)
+      ),
+      is.null,
+      logical(1)
     )
   )
 

--- a/inst/shinyexample/dev/01_start.R
+++ b/inst/shinyexample/dev/01_start.R
@@ -12,7 +12,7 @@
 ########################################
 
 ## Fill the DESCRIPTION ----
-## Add meta data about your application
+## Add meta data about your application and set some default {golem} options
 ##
 ## /!\ Note: if you want to change the name of your app during development,
 ## either re-run this function, call golem::set_golem_name(), or don't forget
@@ -32,11 +32,6 @@ golem::fill_desc(
   pkg_version = "0.0.0.9000", # The version of the package containing the app
   set_options = TRUE # Set the global golem options
 )
-
-## Set {golem} options ----
-## Is highly recommended to run and will be set as the default via
-## fill_desc(..., set_options = TRUE) in future versions of {golem}
-golem::set_golem_options()
 
 ## Install the required dev dependencies ----
 golem::install_dev_deps()

--- a/vignettes/a_start.Rmd
+++ b/vignettes/a_start.Rmd
@@ -25,15 +25,12 @@ knitr::opts_chunk$set(
 
 ## Installing {golem}
 
-+ You can install the stable version of `{golem}` from CRAN:
-
+You can install the stable version of `{golem}` from CRAN:
 ``` {r}
 install.packages("golem")
 ```
 
-
 The development version of `{golem}` can be installed from GitHub using the `{remotes}` package:
-
 ```{r}
 remotes::install_github("Thinkr-open/golem")
 ```
@@ -50,14 +47,13 @@ In the rest of the Vignettes, we'll assume you're working in RStudio.
 
 ### Create a package
 
-Once the package is installed, you can got to File > New Project... in RStudio, and choose "Package for Shiny App Using golem" input.
+Once the package is installed, you can got to _File > New Project..._ in RStudio, and choose _"Package for Shiny App Using golem"_ input:
 
 ```{r, echo=FALSE, out.width="80%", fig.align="center", eval=TRUE}
 knitr::include_graphics("golemtemplate.png")
 ```
 
-
-If you want to do it through command line, you can use:
+If you want to do it inside `R` use:
 
 ```{r}
 golem::create_golem(path = "path/to/package")
@@ -105,11 +101,11 @@ If you're already familiar with R packages, most of these files will seem very f
 
 Once you've created your project, the first file that opens is `dev/01_start.R`. This file contains a series of commands that you'll have to run once, at the beginning of the project.
 
-Note that you don't have to fill everything, event thought it's strongly recommended.
+Note that you don't have to fill everything, even though it's strongly recommended.
 
 ### Fill the DESCRIPTION
 
-First, fill the DESCRIPTION by adding information about the package that will contain your app. The first function, `fill_desc()`, can be used to fill your `DESCRIPTION` file.
+First, fill the `DESCRIPTION` by adding information about the package that will contain your app. The first function, `fill_desc()`, can be used to fill your `DESCRIPTION` file:
 
 ```{r }
 golem::fill_desc(
@@ -121,23 +117,17 @@ golem::fill_desc(
     family = "AUTHOR_LAST", # Your Last Name
     email = "AUTHOR@MAIL.COM", # Your email
     role = c("aut", "cre") # Your role (here author/creator)
+    set_options = TRUE # Set the global golem options
     ),
   repo_url = NULL, # The URL of the GitHub repo (optional),
-  pkg_version = "0.0.0.9000", # The version of the package containing the app,
-  set_options = TRUE # Set the global golem options
+  pkg_version = "0.0.0.9000" # The version of the package containing the app
 )
 ```
 
 About [the DESCRIPTION file](https://r-pkgs.org/description.html).
 
-### Add `{golem}` options
-
-Please DO run this line of code, as it sets a series of global options inside `golem-config.yml` that will be reused inside `{golem}`. It will be set as the default via above fill_desc(..., set_options = TRUE) in future versions of
-{golem}.
-
-```{r}
-golem::set_golem_options()
-```
+Additionally, `fill_desc()` sets a series of recommended global options in
+`golem-config.yml` that will be reused inside `{golem}`.
 
 ### Set common Files
 
@@ -166,7 +156,8 @@ About [tests in a package](https://r-pkgs.org/testing-basics.html).
 
 ### Use Recommended Packages
 
-This will add "shiny", "DT", "attempt", "glue", "htmltools", and "golem" as a dependency to your package.
+This will add `{shiny}`, `{DT}`, `{attempt}`, `{glue}`, `{htmltools}`, and 
+`{golem}` as dependencies to your package:
 
 ```{r}
 golem::use_recommended_deps()
@@ -174,46 +165,44 @@ golem::use_recommended_deps()
 
 ### Add various tools
 
-+ If you want to change the default favicon
-
-```{r}
-# Remove current favicon
-golem::remove_favicon()
-# Add a new one
-golem::use_favicon(path = "path/to/favicon")
-```
-
-Note that you can add an url, and the favicon will be downloaded to the `inst/app/www` folder.
++ If you want to change the default favicon:
+    ```{r}
+    # Remove current favicon
+    golem::remove_favicon()
+    # Add a new one
+    golem::use_favicon(path = "path/to/favicon")
+    ```
+Note that you can add an URL, and the favicon will be downloaded to the `inst/app/www` folder.
 
 > **Note**: If you are deploying your app with [ShinyProxy](https://www.shinyproxy.io/), your favicon should have the `.png` extension, otherwise it is not going to work.
 
-+ Utils
-
-These two functions add a file with various functions that can be used along the process of building your app.
-
-See each file in details for a description of the functions.
-
-```{r}
-golem::use_utils_ui()
-golem::use_utils_server()
-```
++ Utils: these two functions add two files with additional helper functions for
+your `{golem}` project. They can be used along the process of building your app:
+    ```{r}
+    golem::use_utils_ui(with_test = TRUE)
+    golem::use_utils_server(with_test = TRUE)
+    ```
+For a detailed description of the generated functions see the respective files 
+`R/golem_utils_server.R` and `R/golem_utils_ui.R` for which also default tests 
+are added in `tests/testthat` (to suppress this set `with_test = FALSE` in the
+above calls).
 
 ## Try the app
 
-To run the app, launch :
+To launch the app run:
 
 ```{r}
 golem::run_dev()
 ```
 
 
-You're now set! You've successfully initiated the project and can go to dev/02_dev.R.
+You're now set! You've successfully initiated the project and can go to `dev/02_dev.R`:
 
 ```{r}
 rstudioapi::navigateToFile("dev/02_dev.R")
 ```
 
-```{r eval = TRUE}
+```{r, eval = TRUE, include = FALSE}
 try(fs::dir_delete(x), silent = TRUE)
 ```
 

--- a/vignettes/a_start.Rmd
+++ b/vignettes/a_start.Rmd
@@ -53,7 +53,7 @@ Once the package is installed, you can got to _File > New Project..._ in RStudio
 knitr::include_graphics("golemtemplate.png")
 ```
 
-If you want to do it inside `R` use:
+If you want to do it directly via the command line, use:
 
 ```{r}
 golem::create_golem(path = "path/to/package")


### PR DESCRIPTION
could be used to solve #1046 

specifically:

1. as `fill_desc()` no longer only fills the DESCRIPTION but sets some configs one might want to document this more clearly inside the function (_commit 1_)
2. remove some artefacts from `01_start.R`  related to the removed `set_golem_options()` (_commit 2_)
3. face-lifting `vingettes/a_start.Rmd` (_commit 3_):
    - remove artefacts from `set_golem_options()`
    - improve the overall appearance, fixing typos and being consistent on the appearance of the markdown