### PR TITLE
845 path/pkg arg consistency

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -128,9 +128,9 @@ get_current_config <- function(path = getwd()) {
 # set the {golem} name
 change_app_config_name <- function(
   name,
-  path = get_golem_wd()
+  pkg = get_golem_wd()
 ) {
-  pth <- fs_path(path, "R", "app_config.R")
+  pth <- fs_path(pkg, "R", "app_config.R")
   app_config <- readLines(pth)
 
   where_system.file <- grep("system.file", app_config)

--- a/R/desc.R
+++ b/R/desc.R
@@ -113,7 +113,7 @@ fill_desc <- function(
   )
   change_app_config_name(
     name = pkg_name,
-    path = pkg
+    pkg = pkg
   )
   set_golem_name(pkg_name)
 

--- a/R/golem-yaml-get.R
+++ b/R/golem-yaml-get.R
@@ -10,10 +10,10 @@ get_golem_things <- function(
     )
   ),
   use_parent = TRUE,
-  path
+  pkg
 ) {
   conf_path <- get_current_config(
-    path
+    pkg
   )
   stop_if(
     conf_path,
@@ -34,13 +34,13 @@ get_golem_wd <- function(
   use_parent = TRUE,
   pkg = golem::pkg_path()
 ) {
-  path <- fs_path_abs(pkg)
+  pkg <- fs_path_abs(pkg)
 
   pth <- get_golem_things(
     value = "golem_wd",
     config = "dev",
     use_parent = use_parent,
-    path = path
+    pkg = pkg
   )
   if (is.null(pth)) {
     pth <- golem::pkg_path()
@@ -61,12 +61,12 @@ get_golem_name <- function(
   use_parent = TRUE,
   pkg = golem::pkg_path()
 ) {
-  path <- fs_path_abs(pkg)
+  pkg <- fs_path_abs(pkg)
   nm <- get_golem_things(
     value = "golem_name",
     config = config,
     use_parent = use_parent,
-    path = path
+    pkg = pkg
   )
   if (is.null(nm)) {
     nm <- golem::pkg_name()
@@ -87,12 +87,12 @@ get_golem_version <- function(
   use_parent = TRUE,
   pkg = golem::pkg_path()
 ) {
-  path <- fs_path_abs(pkg)
+  pkg <- fs_path_abs(pkg)
   vers <- get_golem_things(
     value = "golem_version",
     config = config,
     use_parent = use_parent,
-    path = path
+    pkg = pkg
   )
   if (is.null(vers)) {
     vers <- golem::pkg_version()

--- a/R/golem-yaml-set.R
+++ b/R/golem-yaml-set.R
@@ -34,7 +34,7 @@ set_golem_name <- function(
   talkative = TRUE,
   old_name = golem::pkg_name()
 ) {
-  path <- fs_path_abs(pkg)
+  pkg <- fs_path_abs(pkg)
 
   # Changing in YAML
   amend_golem_config(
@@ -48,13 +48,13 @@ set_golem_name <- function(
   # Changing in app-config.R
   change_app_config_name(
     name = name,
-    path = path
+    pkg = pkg 
   )
 
   # Changing in DESCRIPTION
   desc <- desc_description(
     file = fs_path(
-      path,
+      pkg,
       "DESCRIPTION"
     )
   )
@@ -69,14 +69,14 @@ set_golem_name <- function(
   set_golem_name_tests(
     old_name = old_name,
     new_name = name,
-    path = path
+    pkg = pkg
   )
 
   # Changing in ./vignettes/ if dir present
   set_golem_name_vignettes(
     old_name = old_name,
     new_name = name,
-    path = path
+    pkg = pkg
   )
 
   if (old_name != name){
@@ -94,10 +94,10 @@ set_golem_name <- function(
 set_golem_name_tests <- function(
   old_name,
   new_name,
-  path
+  pkg
     ) {
   pth_dir_tests <- file.path(
-    path,
+    pkg,
     "tests"
   )
 
@@ -116,10 +116,10 @@ set_golem_name_tests <- function(
 set_golem_name_vignettes <- function(
   old_name,
   new_name,
-  path
+  pkg
     ) {
   pth_dir_vignettes <- file.path(
-    path,
+    pkg,
     "vignettes"
   )
 
@@ -151,7 +151,7 @@ set_golem_version <- function(
   pkg = golem::pkg_path(),
   talkative = TRUE
     ) {
-  path <- fs_path_abs(pkg)
+  pkg <- fs_path_abs(pkg)
 
   # Changing in YAML
   amend_golem_config(
@@ -164,7 +164,7 @@ set_golem_version <- function(
 
   desc <- desc_description(
     file = fs_path(
-      path,
+      pkg,
       "DESCRIPTION"
     )
   )

--- a/R/is_golem.R
+++ b/R/is_golem.R
@@ -1,15 +1,15 @@
 #' Is the directory a golem-based app?
 #'
-#' Trying to guess if `path` is a golem-based app.
+#' Trying to guess if `pkg` is a golem-based app.
 #'
-#' @param path Path to the directory to check.
+#' @param pkg Path to the directory to check.
 #' Defaults to the current working directory.
 #'
 #' @export
 #'
 #' @examples
 #' is_golem()
-is_golem <- function(path = getwd()) {
+is_golem <- function(pkg = getwd()) {
   files_from_shiny_example <- grep(
     "^(?!REMOVEME).*",
     list.files(
@@ -28,6 +28,6 @@ is_golem <- function(path = getwd()) {
   )
 
   all(
-    files_from_shiny_example %in% list.files(path, recursive = TRUE)
+    files_from_shiny_example %in% list.files(pkg, recursive = TRUE)
   )
 }

--- a/R/pkg_tools.R
+++ b/R/pkg_tools.R
@@ -1,6 +1,6 @@
 # Getting the DESCRIPTION file in a data.frame
 daf_desc <- function(
-    path = get_golem_wd(),
+    pkg = get_golem_wd(),
     entry) {
   as.character(
     unlist(
@@ -8,7 +8,7 @@ daf_desc <- function(
         as.data.frame(
           read.dcf(
             normalizePath(
-              fs_path(path, "DESCRIPTION")
+              fs_path(pkg, "DESCRIPTION")
             )
           )
         )[entry]
@@ -22,19 +22,19 @@ daf_desc <- function(
 #' These are functions to help you navigate
 #' inside your project while developing
 #'
-#' @param path Path to use to read the DESCRIPTION
+#' @param pkg Path to use to read the DESCRIPTION
 #'
 #' @export
 #' @rdname pkg_tools
 #'
 #' @return The value of the entry in the DESCRIPTION file
-pkg_name <- function(path = get_golem_wd()) {
-  daf_desc(path, "Package")
+pkg_name <- function(pkg = get_golem_wd()) {
+  daf_desc(pkg, "Package")
 }
 #' @export
 #' @rdname pkg_tools
-pkg_version <- function(path = get_golem_wd()) {
-  daf_desc(path, "Version")
+pkg_version <- function(pkg = get_golem_wd()) {
+  daf_desc(pkg, "Version")
 }
 #' @export
 #' @rdname pkg_tools

--- a/man/is_golem.Rd
+++ b/man/is_golem.Rd
@@ -4,14 +4,14 @@
 \alias{is_golem}
 \title{Is the directory a golem-based app?}
 \usage{
-is_golem(path = getwd())
+is_golem(pkg = getwd())
 }
 \arguments{
-\item{path}{Path to the directory to check.
+\item{pkg}{Path to the directory to check.
 Defaults to the current working directory.}
 }
 \description{
-Trying to guess if \code{path} is a golem-based app.
+Trying to guess if \code{pkg} is a golem-based app.
 }
 \examples{
 is_golem()

--- a/man/pkg_tools.Rd
+++ b/man/pkg_tools.Rd
@@ -6,14 +6,14 @@
 \alias{pkg_path}
 \title{Package tools}
 \usage{
-pkg_name(path = get_golem_wd())
+pkg_name(pkg = get_golem_wd())
 
-pkg_version(path = get_golem_wd())
+pkg_version(pkg = get_golem_wd())
 
 pkg_path()
 }
 \arguments{
-\item{path}{Path to use to read the DESCRIPTION}
+\item{pkg}{Path to use to read the DESCRIPTION}
 }
 \value{
 The value of the entry in the DESCRIPTION file


### PR DESCRIPTION
fixes #845 

Maybe `path` is a bit more general because it can be used for files and package-dirs, but the issue suggests `pkg`. 

I have made a commit per file to identify the instances so if required one can quickly change from `pkg` back to `path`. 



### DONE: path - > pkg changes

- `R/golem-yaml-get.R`
- `R/config.R`
- `R/golem-yaml-set.R`
- `R/is_golem.R`
- `R/pkg_tools.R`


### TO-DO: decide here I do not think `pkg` makes sense because:

1. sometimes `path` is  __*a path to a file*__ so `pkg` is just weird:
       - `utils.R` - > `create_if_needed()`-dance for __*files*__ 
       - `use_file.R` - > template __*files*__
       - `use_favicon.R` - > path to favicon __*files*__
       - `templates.R` - > all functions refer to template __*files*__ I think
       - `modules_fn.R` - > `module_template()` it does use a path to a __*file*__
       - `add_r_files.R` - > `append_roxygen_comment()` path to the R script where the module will be 	
       - `bundle_resources.R` - > `bundle_resources()` needs a path to a subdir, not the package 
       - `config.R` - > everything but the last function attempts to find a config-file trying different paths
       - `create_golem.R` - > creates a golem in the specified `path` and the `package_name` can be seperately
       - `enable_roxygenize` -> path to .Rproj file

2. for bootstrapped functions, same as above, plus their args are already named path, I wouldn’t want to change that:
	- `bootstrap_fs.R`
	- `bootstrap_attachment.R`
	- `bootstrap_dockerfiler.R`
	- `bootstrap_pkgload.R`
	- `bootstrap_usethis.R`