### PR TITLE
add user supplied `file` for `run_dev()` & make covr. 100% for `run_dev.R` 

### DIFF
--- a/R/run_dev.R
+++ b/R/run_dev.R
@@ -1,12 +1,25 @@
-#' Run run_dev.R
+#' Run the `run_dev.R` file
 #'
-#' @param file File path to `run_dev.R`. Defaults to `R/run_dev.R`.
-#' @param save_all boolean. If TRUE, save all open file before sourcing `file`
+#' The default `file="dev/run_dev.R"` launches your `{golem}` app with a bunch
+#' of useful options. The file content can be customized and `file`-name and
+#' path changed as long as the argument combination of `file` and `pkg` are
+#' supplied correctly: the `file`-path is a relative path to a `{golem}`-package
+#' root `pkg`. An error is thrown if `pkg/file` cannot be found.
+#'
+#' The function `run_dev()` is typically used to launch a shiny app by sourcing
+#' the content of an appropriate `run_dev`-file. Carefully read the content of
+#' `dev/run_dev.R` when creating your custom `run_dev`-file. It has already
+#' many useful settings including a switch between production/development,
+#' reloading the package in a clean `R` environment before running the app etc.
+#'
+#' @param file String with (relative) file path to a `run_dev.R`-file
+#' @param save_all Boolean; if `TRUE` saves all open files before sourcing
+#'     `file`
 #' @inheritParams add_module
 #'
 #' @export
 #'
-#' @return Used for side-effect
+#' @return pure side-effect function; returns invisibly
 run_dev <- function(
   file = "dev/run_dev.R",
   pkg = get_golem_wd(),
@@ -43,4 +56,5 @@ run_dev <- function(
       text = run_dev_lines
     )
   )
+  return(invisible(file))
 }

--- a/R/run_dev.R
+++ b/R/run_dev.R
@@ -31,12 +31,10 @@ run_dev <- function(
 
   # Stop if it doesn't exists
   if (file.exists(try_dev)) {
-    run_dev_lines <- readLines(
-      "dev/run_dev.R"
-    )
+    run_dev_lines <- readLines(try_dev)
   } else {
     stop(
-      "Unable to locate dev file"
+      "Unable to locate the run_dev-file passed via the 'file' argument."
     )
   }
 

--- a/tests/testthat/test-run_dev.R
+++ b/tests/testthat/test-run_dev.R
@@ -1,0 +1,47 @@
+path_dummy_golem <- tempfile(pattern = "dummygolem")
+create_golem(
+  path = path_dummy_golem,
+  open = FALSE
+)
+test_that("run_dev() works for different files and fails if missing", {
+  with_dir(
+    path_dummy_golem,
+    {
+      # Adjust file for testing run_dev() with default file="dev/run_dev.R"
+      run_dev_update <- readLines("dev/run_dev.R")
+      # suppress other behavior of run_dev that is not meant for testing
+      run_dev_update[2] <- "# options(golem.app.prod = FALSE)"
+      run_dev_update[6] <- "# options(shiny.port = httpuv::randomPort())"
+      run_dev_update[8] <- "# golem::detach_all_attached()"
+      run_dev_update[12] <- "# golem::document_and_reload()"
+      run_dev_update[15] <- "print('DEFAULT run_dev')"
+      # write new run_dev.R file for testing
+      run_dev_update <- writeLines(run_dev_update, "dev/run_dev.R")
+      # Make a copy of run_dev and move it elsewhere (but inside golem)
+      file.copy(
+        from = "dev/run_dev.R",
+        to = file.path(get_golem_wd(), "run_dev2.R")
+      )
+      # Adjust copy for testing run_dev() with user supplied file="run_dev2.R"
+      run_dev_update <- readLines("run_dev2.R")
+      run_dev_update[15] <- "print('NEW run_dev2')"
+      run_dev_update <- writeLines(run_dev_update, "run_dev2.R")
+      # The default run_dev works
+      expect_output(
+        run_dev(),
+        regexp = "DEFAULT run_dev"
+      )
+      # The new run_dev2 works too
+      expect_output(
+        run_dev(file = "run_dev2.R"),
+        regexp = "NEW run_dev2"
+      )
+      # A wrong path supplied to 'file' fails  with informative error
+      expect_error(
+        run_dev(file = "run_dev3.R"),
+        regexp = "Unable to locate the run_dev-file passed via the 'file' argument."
+      )
+      unlink(path_dummy_golem, recursive = TRUE)
+    }
+  )
+})


### PR DESCRIPTION
Fix #886

1. fix: for the current `dev` version of `run_dev()` this is (I think) a one-liner so I updated a bit the error message as well (see commit daae6628a528458d191d4bd858ce9d8a8e152969)

2. tests: `run_dev()` is currently not tested, so move coverage of `golem/R/run_dev.R` from 0% to 100% with some tests (see commit 7c44d5225257dc806fed75d1a6b4a9aa31ef4790):

3. update docs; it’s one of the most used functions (see commit 928f9fee8a70b8bbd4da4f1a064481346d3f1d2b)