### PR TITLE
Fix 1058, 1060, 1062 and improve code coverage in `use_files.R` from 0 to 100%

### DIFF
--- a/R/use_files.R
+++ b/R/use_files.R
@@ -23,7 +23,7 @@ use_external_js_file <- function(
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
-) {
+    ) {
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
@@ -36,12 +36,19 @@ use_external_js_file <- function(
   name <- file_path_sans_ext(name)
   new_file <- sprintf("%s.js", name)
 
-  dir_created <- create_if_needed(
-    dir,
-    type = "directory"
+  dir_created <- tryCatch(
+    create_if_needed(
+      dir,
+      type = "directory"
+    ),
+    error = function(e) {
+      out <- FALSE
+      names(out) <- e[[1]]
+      return(out)
+    }
   )
 
-  if (!dir_created) {
+  if (isFALSE(dir_created)) {
     cat_dir_necessary()
     return(invisible(FALSE))
   }
@@ -90,7 +97,7 @@ use_external_css_file <- function(
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
-) {
+    ) {
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
@@ -103,12 +110,19 @@ use_external_css_file <- function(
   name <- file_path_sans_ext(name)
   new_file <- sprintf("%s.css", name)
 
-  dir_created <- create_if_needed(
-    dir,
-    type = "directory"
+  dir_created <- tryCatch(
+    create_if_needed(
+      dir,
+      type = "directory"
+    ),
+    error = function(e) {
+      out <- FALSE
+      names(out) <- e[[1]]
+      return(out)
+    }
   )
 
-  if (!dir_created) {
+  if (isFALSE(dir_created)) {
     cat_dir_necessary()
     return(invisible(FALSE))
   }
@@ -157,7 +171,7 @@ use_external_html_template <- function(
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
-) {
+    ) {
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
@@ -168,12 +182,19 @@ use_external_html_template <- function(
 
   check_name_length(name)
 
-  dir_created <- create_if_needed(
-    dir,
-    type = "directory"
+  dir_created <- tryCatch(
+    create_if_needed(
+      dir,
+      type = "directory"
+    ),
+    error = function(e) {
+      out <- FALSE
+      names(out) <- e[[1]]
+      return(out)
+    }
   )
 
-  if (!dir_created) {
+  if (isFALSE(dir_created)) {
     cat_dir_necessary()
     return(invisible(FALSE))
   }
@@ -216,8 +237,7 @@ use_external_file <- function(
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
-) {
-
+    ) {
   if (missing(name)) {
     name <- basename(url)
   }
@@ -227,12 +247,19 @@ use_external_file <- function(
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
-  dir_created <- create_if_needed(
-    dir,
-    type = "directory"
+  dir_created <- tryCatch(
+    create_if_needed(
+      dir,
+      type = "directory"
+    ),
+    error = function(e) {
+      out <- FALSE
+      names(out) <- e[[1]]
+      return(out)
+    }
   )
 
-  if (!dir_created) {
+  if (isFALSE(dir_created)) {
     cat_dir_necessary()
     return(invisible(FALSE))
   }
@@ -265,7 +292,7 @@ use_internal_js_file <- function(
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
-) {
+    ) {
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
@@ -278,12 +305,19 @@ use_internal_js_file <- function(
   name <- file_path_sans_ext(name)
   new_file <- sprintf("%s.js", name)
 
-  dir_created <- create_if_needed(
-    dir,
-    type = "directory"
+  dir_created <- tryCatch(
+    create_if_needed(
+      dir,
+      type = "directory"
+    ),
+    error = function(e) {
+      out <- FALSE
+      names(out) <- e[[1]]
+      return(out)
+    }
   )
 
-  if (!dir_created) {
+  if (isFALSE(dir_created)) {
     cat_dir_necessary()
     return(invisible(FALSE))
   }
@@ -331,8 +365,7 @@ use_internal_css_file <- function(
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
-) {
-
+    ) {
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
@@ -345,12 +378,19 @@ use_internal_css_file <- function(
   name <- file_path_sans_ext(name)
   new_file <- sprintf("%s.css", name)
 
-  dir_created <- create_if_needed(
-    dir,
-    type = "directory"
+  dir_created <- tryCatch(
+    create_if_needed(
+      dir,
+      type = "directory"
+    ),
+    error = function(e) {
+      out <- FALSE
+      names(out) <- e[[1]]
+      return(out)
+    }
   )
 
-  if (!dir_created) {
+  if (isFALSE(dir_created)) {
     cat_dir_necessary()
     return(invisible(FALSE))
   }
@@ -398,7 +438,7 @@ use_internal_html_template <- function(
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
-) {
+    ) {
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
@@ -409,12 +449,19 @@ use_internal_html_template <- function(
     file_path_sans_ext(name)
   )
 
-  dir_created <- create_if_needed(
-    dir,
-    type = "directory"
+  dir_created <- tryCatch(
+    create_if_needed(
+      dir,
+      type = "directory"
+    ),
+    error = function(e) {
+      out <- FALSE
+      names(out) <- e[[1]]
+      return(out)
+    }
   )
 
-  if (!dir_created) {
+  if (isFALSE(dir_created)) {
     cat_dir_necessary()
     return(invisible(FALSE))
   }
@@ -456,7 +503,7 @@ use_internal_file <- function(
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
-) {
+    ) {
   if (missing(name)) {
     name <- basename(path)
   }
@@ -466,12 +513,19 @@ use_internal_file <- function(
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
-  dir_created <- create_if_needed(
-    dir,
-    type = "directory"
+  dir_created <- tryCatch(
+    create_if_needed(
+      dir,
+      type = "directory"
+    ),
+    error = function(e) {
+      out <- FALSE
+      names(out) <- e[[1]]
+      return(out)
+    }
   )
 
-  if (!dir_created) {
+  if (isFALSE(dir_created)) {
     cat_dir_necessary()
     return(invisible(FALSE))
   }

--- a/R/use_files.R
+++ b/R/use_files.R
@@ -18,7 +18,7 @@
 #' @return The path to the file, invisibly.
 use_external_js_file <- function(
   url,
-  name,
+  name = NULL,
   pkg = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
@@ -85,7 +85,7 @@ use_external_js_file <- function(
 #' @rdname use_files
 use_external_css_file <- function(
   url,
-  name,
+  name = NULL,
   pkg = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
@@ -211,18 +211,18 @@ use_external_html_template <- function(
 #' @rdname use_files
 use_external_file <- function(
   url,
-  name,
+  name = NULL,
   pkg = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
 ) {
-  check_name_length(name)
 
   if (missing(name)) {
     name <- basename(url)
   }
 
+  check_name_length(name)
 
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
@@ -260,19 +260,20 @@ use_external_file <- function(
 #' @rdname use_files
 use_internal_js_file <- function(
   path,
-  name,
+  name = NULL,
   pkg = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
 ) {
-  check_name_length(name)
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
 
   if (missing(name)) {
     name <- basename(path)
   }
+
+  check_name_length(name)
 
   name <- file_path_sans_ext(name)
   new_file <- sprintf("%s.js", name)
@@ -325,13 +326,12 @@ use_internal_js_file <- function(
 #' @rdname use_files
 use_internal_css_file <- function(
   path,
-  name,
+  name = NULL,
   pkg = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
   dir_create = TRUE
 ) {
-  check_name_length(name)
 
   old <- setwd(fs_path_abs(pkg))
   on.exit(setwd(old))
@@ -339,6 +339,8 @@ use_internal_css_file <- function(
   if (missing(name)) {
     name <- basename(path)
   }
+
+  check_name_length(name)
 
   name <- file_path_sans_ext(name)
   new_file <- sprintf("%s.css", name)
@@ -449,7 +451,7 @@ use_internal_html_template <- function(
 #' @rdname use_files
 use_internal_file <- function(
   path,
-  name,
+  name = NULL,
   pkg = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,

--- a/inst/utils/testfile_template_css.css
+++ b/inst/utils/testfile_template_css.css
@@ -1,0 +1,13 @@
+ body {
+  background-color: lightblue;
+}
+
+h1 {
+  color: white;
+  text-align: center;
+}
+
+p {
+  font-family: verdana;
+  font-size: 20px;
+}

--- a/inst/utils/testfile_template_html.html
+++ b/inst/utils/testfile_template_html.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<h1>My First Heading</h1>
+
+<p>My first paragraph.</p>
+
+</body>
+</html>

--- a/inst/utils/testfile_template_js.js
+++ b/inst/utils/testfile_template_js.js
@@ -1,0 +1,2 @@
+const myHeading = document.querySelector("h1");
+myHeading.textContent = "Hello world!";

--- a/inst/utils/testfile_template_plainfile.txt
+++ b/inst/utils/testfile_template_plainfile.txt
@@ -1,0 +1,1 @@
+Some text.

--- a/tests/testthat/test-use_files.R
+++ b/tests/testthat/test-use_files.R
@@ -8,9 +8,9 @@ test_that("use_external_XXX_files() function family works properly", {
     path_dummy_golem,
     {
       # I. test the external ".txt" file download
+      # I.A standard case
       use_external_file(
-        url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_plainfile.txt",
-        name = "testfile_template_plainfile.txt"
+        url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_plainfile.txt"
       )
       test_file_download <- readLines(
         "inst/app/www/testfile_template_plainfile.txt"
@@ -19,8 +19,24 @@ test_that("use_external_XXX_files() function family works properly", {
         test_file_download,
         "Some text."
       )
+      # I.B corner case: file already exists
+      expect_false(
+        use_external_file(
+          url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_plainfile.txt",
+          name = "testfile_template_plainfile.txt"
+        )
+      )
+      # I.C corner case: dir already exists
+      expect_false(
+        use_external_file(
+          url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_plainfile.txt",
+          name = "testfile_template_plainfile3.txt",
+          dir = "inst/app/www2"
+        )
+      )
 
       # II. test the external ".html" file download
+      # II.A standard case
       use_external_html_template(
         url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_html.html",
         name = "testfile_template_html.html"
@@ -43,11 +59,26 @@ test_that("use_external_XXX_files() function family works properly", {
           "</html>"
         )
       )
+      # II.B corner case: file already exists
+      expect_false(
+        use_external_html_template(
+          url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_html.html",
+          name = "testfile_template_html.html"
+        )
+      )
+      # II.C corner case: dir already exists
+      expect_false(
+        use_external_html_template(
+          url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_html.html",
+          name = "testfile_template_html2.html",
+          dir = "inst/app/www2"
+        )
+      )
 
       # III. test the external ".js" file download
+      # III.A standard case
       use_external_js_file(
-        url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_js.js",
-        name = "testfile_template_js.js"
+        url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_js.js"
       )
       test_file_download <- readLines(
         "inst/app/www/testfile_template_js.js"
@@ -59,11 +90,33 @@ test_that("use_external_XXX_files() function family works properly", {
           "myHeading.textContent = \"Hello world!\";"
         )
       )
+      # III.B corner case: file already exists
+      expect_false(
+        use_external_js_file(
+          url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_js.js",
+          name = "testfile_template_js.js"
+        )
+      )
+      # III.C corner case: dir already exists
+      expect_false(
+        use_external_js_file(
+          url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_js.js",
+          name = "testfile_template_js2.js",
+          dir = "inst/app/www2"
+        )
+      )
+      # III.D corner case: URL does not have extension ".js"
+      expect_false(
+        use_external_js_file(
+          url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_js",
+          name = "testfile_template_js3.js"
+        )
+      )
 
       # IV. test the external ".css" file download
+      # IV.A standard case
       use_external_css_file(
-        url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_css.css",
-        name = "testfile_template_css.css"
+        url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_css.css"
       )
       test_file_download <- readLines(
         "inst/app/www/testfile_template_css.css"
@@ -86,6 +139,29 @@ test_that("use_external_XXX_files() function family works properly", {
           "}"
         )
       )
+      # IV.B corner case: file already exists
+      expect_false(
+        use_external_css_file(
+          url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_css.css",
+          name = "testfile_template_css.css"
+        )
+      )
+      # IV.C corner case: dir already exists
+      expect_false(
+        use_external_css_file(
+          url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_css.css",
+          name = "testfile_template_css2.css",
+          dir = "inst/app/www2"
+        )
+      )
+      # IV.D corner case: URL does not have extension ".css"
+      expect_false(
+        use_external_css_file(
+          url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_css",
+          name = "testfile_template_css3.css"
+        )
+      )
+
       unlink(path_dummy_golem, recursive = TRUE)
     }
   )
@@ -118,13 +194,13 @@ test_that("use_internal_XXX_files() function family works properly", {
     path_dummy_golem,
     {
       # I. test the internal ".txt" file usage
+      # I.A standard case
       use_internal_file(
         path = file.path(
           path_dummy_golem,
           "tmp_dump_testfiles",
           "testfile_template_plainfile.txt"
-        ),
-        name = "testfile_template_plainfile.txt"
+        )
       )
       test_file_download <- readLines(
         "inst/app/www/testfile_template_plainfile.txt"
@@ -133,8 +209,32 @@ test_that("use_internal_XXX_files() function family works properly", {
         test_file_download,
         "Some text."
       )
+      # I.B corner case: file already exists
+      expect_false(
+        use_internal_file(
+          path = file.path(
+            path_dummy_golem,
+            "tmp_dump_testfiles",
+            "testfile_template_plainfile.txt"
+          ),
+          name = "testfile_template_plainfile.txt"
+        )
+      )
+      # I.C corner case: dir already exists
+      expect_false(
+        use_internal_file(
+          path = file.path(
+            path_dummy_golem,
+            "tmp_dump_testfiles",
+            "testfile_template_plainfile.txt"
+          ),
+          name = "testfile_template_plainfile2.txt",
+          dir = "inst/app/www2"
+        )
+      )
 
       # II. test the internal ".html" file usage
+      # II.A standard case
       use_internal_html_template(
         path = file.path(
           path_dummy_golem,
@@ -161,15 +261,38 @@ test_that("use_internal_XXX_files() function family works properly", {
           "</html>"
         )
       )
+      # II.B corner case: file already exists
+      expect_false(
+        use_internal_html_template(
+          path = file.path(
+            path_dummy_golem,
+            "tmp_dump_testfiles",
+            "testfile_template_html.html"
+          ),
+          name = "testfile_template_html.html"
+        )
+      )
+      # II.C corner case: dir already exists
+      expect_false(
+        use_internal_html_template(
+          path = file.path(
+            path_dummy_golem,
+            "tmp_dump_testfiles",
+            "testfile_template_html.html"
+          ),
+          name = "testfile_template_html2.html",
+          dir = "inst/app/www2"
+        )
+      )
 
       # III. test the internal ".js" file usage
+      # III.A standard case
       use_internal_js_file(
         path = file.path(
           path_dummy_golem,
           "tmp_dump_testfiles",
           "testfile_template_js.js"
-        ),
-        name = "testfile_template_js.js"
+        )
       )
       test_file_download <- readLines(
         "inst/app/www/testfile_template_js.js"
@@ -181,15 +304,49 @@ test_that("use_internal_XXX_files() function family works properly", {
           "myHeading.textContent = \"Hello world!\";"
         )
       )
+      # III.B corner case: file already exists
+      expect_false(
+        use_internal_js_file(
+          path = file.path(
+            path_dummy_golem,
+            "tmp_dump_testfiles",
+            "testfile_template_js.js"
+          ),
+          name = "testfile_template_js.js"
+        )
+      )
+      # III.C corner case: dir already exists
+      expect_false(
+        use_internal_js_file(
+          path = file.path(
+            path_dummy_golem,
+            "tmp_dump_testfiles",
+            "testfile_template_js2.js"
+          ),
+          name = "testfile_template_js.js",
+          dir = "inst/app/www2"
+        )
+      )
+      # III.D corner case: file path does not have extension ".js"
+      expect_false(
+        use_internal_js_file(
+          path = file.path(
+            path_dummy_golem,
+            "tmp_dump_testfiles",
+            "testfile_template_js"
+          ),
+          name = "testfile_template_js3.js"
+        )
+      )
 
       # IV. test the internal ".css" file usage
+      # IV.A standard case
       use_internal_css_file(
         path = file.path(
           path_dummy_golem,
           "tmp_dump_testfiles",
           "testfile_template_css.css"
-        ),
-        name = "testfile_template_css.css"
+        )
       )
       test_file_download <- readLines(
         "inst/app/www/testfile_template_css.css"
@@ -212,6 +369,41 @@ test_that("use_internal_XXX_files() function family works properly", {
           "}"
         )
       )
+      # IV.B corner case: file already exists
+      expect_false(
+        use_internal_css_file(
+          path = file.path(
+            path_dummy_golem,
+            "tmp_dump_testfiles",
+            "testfile_template_css.css"
+          ),
+          name = "testfile_template_css.css"
+        )
+      )
+      # IV.C corner case: dir already exists
+      expect_false(
+        use_internal_css_file(
+          path = file.path(
+            path_dummy_golem,
+            "tmp_dump_testfiles",
+            "testfile_template_css.css"
+          ),
+          name = "testfile_template_css2.css",
+          dir = "inst/app/www2"
+        )
+      )
+      # IV.D corner case: file path does not have extension ".css"
+      expect_false(
+        use_internal_css_file(
+          path = file.path(
+            path_dummy_golem,
+            "tmp_dump_testfiles",
+            "testfile_template_css"
+          ),
+          name = "testfile_template_css3.css"
+        )
+      )
+
       unlink(path_dummy_golem, recursive = TRUE)
     }
   )

--- a/tests/testthat/test-use_files.R
+++ b/tests/testthat/test-use_files.R
@@ -23,16 +23,25 @@ test_that("use_external_XXX_files() function family works properly", {
       # II. test the external ".html" file download
       use_external_html_template(
         url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_html.html",
-        name = "testfile_template_plainfile.html"
+        name = "testfile_template_html.html"
       )
       test_file_download <- readLines(
-        "inst/app/www/testfile_template_plainfile.html"
+        "inst/app/www/testfile_template_html.html"
       )
       expect_identical(
         test_file_download,
-        c("<!DOCTYPE html>", "<html>", "<body>", "",
-          "<h1>My First Heading</h1>", "", "<p>My first paragraph.</p>", "",
-          "</body>","</html>")
+        c(
+          "<!DOCTYPE html>",
+          "<html>",
+          "<body>",
+          "",
+          "<h1>My First Heading</h1>",
+          "",
+          "<p>My first paragraph.</p>",
+          "",
+          "</body>",
+          "</html>"
+        )
       )
 
       # III. test the external ".js" file download
@@ -45,8 +54,10 @@ test_that("use_external_XXX_files() function family works properly", {
       )
       expect_identical(
         test_file_download,
-        c("const myHeading = document.querySelector(\"h1\");",
-          "myHeading.textContent = \"Hello world!\";")
+        c(
+          "const myHeading = document.querySelector(\"h1\");",
+          "myHeading.textContent = \"Hello world!\";"
+        )
       )
 
       # IV. test the external ".css" file download
@@ -59,7 +70,134 @@ test_that("use_external_XXX_files() function family works properly", {
       )
       expect_identical(
         test_file_download,
-        c(" body {",
+        c(
+          " body {",
+          "  background-color: lightblue;",
+          "}",
+          "",
+          "h1 {",
+          "  color: white;",
+          "  text-align: center;",
+          "}",
+          "",
+          "p {",
+          "  font-family: verdana;",
+          "  font-size: 20px;",
+          "}"
+        )
+      )
+      unlink(path_dummy_golem, recursive = TRUE)
+    }
+  )
+})
+test_that("use_internal_XXX_files() function family works properly", {
+  path_dummy_golem <- tempfile(pattern = "dummygolem")
+  create_golem(
+    path = path_dummy_golem,
+    open = FALSE
+  )
+  dir.create(file.path(path_dummy_golem, "tmp_dump_testfiles"))
+  file.copy(
+    from = file.path(
+      .libPaths()[1],
+      "golem",
+      "utils",
+      c(
+        "testfile_template_plainfile.txt",
+        "testfile_template_html.html",
+        "testfile_template_js.js",
+        "testfile_template_css.css"
+      )
+    ),
+    to = file.path(
+      path_dummy_golem,
+      "tmp_dump_testfiles"
+    )
+  )
+  with_dir(
+    path_dummy_golem,
+    {
+      # I. test the internal ".txt" file usage
+      use_internal_file(
+        path = file.path(
+          path_dummy_golem,
+          "tmp_dump_testfiles",
+          "testfile_template_plainfile.txt"
+        ),
+        name = "testfile_template_plainfile.txt"
+      )
+      test_file_download <- readLines(
+        "inst/app/www/testfile_template_plainfile.txt"
+      )
+      expect_identical(
+        test_file_download,
+        "Some text."
+      )
+
+      # II. test the internal ".html" file usage
+      use_internal_html_template(
+        path = file.path(
+          path_dummy_golem,
+          "tmp_dump_testfiles",
+          "testfile_template_html.html"
+        ),
+        name = "testfile_template_html.html"
+      )
+      test_file_download <- readLines(
+        "inst/app/www/testfile_template_html.html"
+      )
+      expect_identical(
+        test_file_download,
+        c(
+          "<!DOCTYPE html>",
+          "<html>",
+          "<body>",
+          "",
+          "<h1>My First Heading</h1>",
+          "",
+          "<p>My first paragraph.</p>",
+          "",
+          "</body>",
+          "</html>"
+        )
+      )
+
+      # III. test the internal ".js" file usage
+      use_internal_js_file(
+        path = file.path(
+          path_dummy_golem,
+          "tmp_dump_testfiles",
+          "testfile_template_js.js"
+        ),
+        name = "testfile_template_js.js"
+      )
+      test_file_download <- readLines(
+        "inst/app/www/testfile_template_js.js"
+      )
+      expect_identical(
+        test_file_download,
+        c(
+          "const myHeading = document.querySelector(\"h1\");",
+          "myHeading.textContent = \"Hello world!\";"
+        )
+      )
+
+      # IV. test the internal ".css" file usage
+      use_internal_css_file(
+        path = file.path(
+          path_dummy_golem,
+          "tmp_dump_testfiles",
+          "testfile_template_css.css"
+        ),
+        name = "testfile_template_css.css"
+      )
+      test_file_download <- readLines(
+        "inst/app/www/testfile_template_css.css"
+      )
+      expect_identical(
+        test_file_download,
+        c(
+          " body {",
           "  background-color: lightblue;",
           "}",
           "",

--- a/tests/testthat/test-use_files.R
+++ b/tests/testthat/test-use_files.R
@@ -1,0 +1,80 @@
+test_that("use_external_XXX_files() function family works properly", {
+  path_dummy_golem <- tempfile(pattern = "dummygolem")
+  create_golem(
+    path = path_dummy_golem,
+    open = FALSE
+  )
+  with_dir(
+    path_dummy_golem,
+    {
+      # I. test the external ".txt" file download
+      use_external_file(
+        url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_plainfile.txt",
+        name = "testfile_template_plainfile.txt"
+      )
+      test_file_download <- readLines(
+        "inst/app/www/testfile_template_plainfile.txt"
+      )
+      expect_identical(
+        test_file_download,
+        "Some text."
+      )
+
+      # II. test the external ".html" file download
+      use_external_html_template(
+        url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_html.html",
+        name = "testfile_template_plainfile.html"
+      )
+      test_file_download <- readLines(
+        "inst/app/www/testfile_template_plainfile.html"
+      )
+      expect_identical(
+        test_file_download,
+        c("<!DOCTYPE html>", "<html>", "<body>", "",
+          "<h1>My First Heading</h1>", "", "<p>My first paragraph.</p>", "",
+          "</body>","</html>")
+      )
+
+      # III. test the external ".js" file download
+      use_external_js_file(
+        url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_js.js",
+        name = "testfile_template_js.js"
+      )
+      test_file_download <- readLines(
+        "inst/app/www/testfile_template_js.js"
+      )
+      expect_identical(
+        test_file_download,
+        c("const myHeading = document.querySelector(\"h1\");",
+          "myHeading.textContent = \"Hello world!\";")
+      )
+
+      # IV. test the external ".css" file download
+      use_external_css_file(
+        url = "https://raw.githubusercontent.com/ilyaZar/golem/fix-1058/inst/utils/testfile_template_css.css",
+        name = "testfile_template_css.css"
+      )
+      test_file_download <- readLines(
+        "inst/app/www/testfile_template_css.css"
+      )
+      expect_identical(
+        test_file_download,
+        c(" body {",
+          "  background-color: lightblue;",
+          "}",
+          "",
+          "h1 {",
+          "  color: white;",
+          "  text-align: center;",
+          "}",
+          "",
+          "p {",
+          "  font-family: verdana;",
+          "  font-size: 20px;",
+          "}"
+        )
+      )
+      unlink(path_dummy_golem, recursive = TRUE)
+    }
+  )
+})


### PR DESCRIPTION
Fix #1058 
Fix #1060 
Fix #1062 

The testing strategy is to:

1. generate template files in `inst/utils`
2. make the `use_external_XXX_files()` function family download these templates (from the Github repo) and compare their content to a hard-coded result
3. make the `use_internal_XXX_files()` function family copy these files internally (from `inst/utils`) and compare their content to the same hard-coded result

#### To-Do/ Note keeping

- [x] template files generated
- [x] `use_external_XXX_files()`: download these templates, check correctness via `readLines()`
- [x]  `use_external_XXX_files()`: go through corner cases to make coverage 100% for these functions
- [x] `use_internal_XXX_files()`: copy internally these templates, check correctness via `readLines()`
- [x]  `use_internal_XXX_files()`: go through corner cases to make coverage 100% for these functions

#### Important

Eventually one needs to get rid of the links to the external files in https://github.com/ilyaZar/golem/tree/fix-1058/inst/utils . Currently these links are necessary because otherwise there is no access to the external files to check if the download works properly.

However, if this PR gets merged and the template-testing files are available (inside the branch where the merge happens), one can change the external links to point to the respective branch under the `https://github.com/ThinkR-open/golem/` repository directly.

So the tests will always work from then onwards, without links to external sources. The link changes should be added via a follow up PR.