### PR TITLE
Fix 1031

### DIFF
--- a/inst/shinyexample/dev/03_deploy.R
+++ b/inst/shinyexample/dev/03_deploy.R
@@ -25,8 +25,8 @@ rhub::check_for_cran()
 ## sent to CRAN, or to a package manager
 devtools::build()
 
-## RStudio ----
-## If you want to deploy on RStudio related platforms
+## Posit ----
+## If you want to deploy on Posit related platforms
 golem::add_rstudioconnect_file()
 golem::add_shinyappsio_file()
 golem::add_shinyserver_file()
@@ -34,13 +34,13 @@ golem::add_shinyserver_file()
 ## Docker ----
 ## If you want to deploy via a generic Dockerfile
 golem::add_dockerfile_with_renv()
-
 ## If you want to deploy to ShinyProxy
 golem::add_dockerfile_with_renv_shinyproxy()
 
-
-# Deploy to Posit Connect or ShinyApps.io
-# In command line.
+## Deploy to Posit Connect or ShinyApps.io ----
+## Add/update manifest file (optional; for Git backed deployment on Posit )
+rsconnect::writeManifest()
+## In command line.
 rsconnect::deployApp(
   appName = desc::desc_get_field("Package"),
   appTitle = desc::desc_get_field("Package"),

--- a/vignettes/c_deploy.Rmd
+++ b/vignettes/c_deploy.Rmd
@@ -25,7 +25,8 @@ knitr::opts_chunk$set(
 
 ## About the `run_app()` function
 
-When launching the app, you might have noticed that the `dev/run_dev.R` function calls `run_app()`, which has the following structure:
+When launching the app, you might have noticed that the `dev/run_dev.R` function
+calls `run_app()`, which has the following structure:
 
 ```{r}
 run_app <- function(...) {
@@ -39,9 +40,14 @@ run_app <- function(...) {
 }
 ```
 
-This function might looks a little bit weird, but there's a long story behind it, and you can read more about it [there](https://rtask.thinkr.fr/shinyapp-runapp-shinyappdir-difference/).
+This function might look a little bit weird, but there's a long story behind
+it, and you can read more about it
+[there](https://rtask.thinkr.fr/shinyapp-runapp-shinyappdir-difference/).
 
-But long story short, this combination of `with_golem_options` & `golem_opts = list(...)` allows you to pass argument to the function to be used inside the application, from UI or from server side, which you can get with `get_golem_options()`.
+But long story short, this combination of `with_golem_options` & `golem_opts =
+list(...)` allows you to pass arguments to the function to be used inside the
+application, from UI or from server side, which you can get with
+`get_golem_options()`.
 
 ```{r}
 run_app(this = "that")
@@ -49,13 +55,14 @@ run_app(this = "that")
 this <- get_golem_options("this")
 ```
 
-The idea is to provide more flexibility for deployment on each platform you want to run your app on.
+The idea is to provide more flexibility for deployment on each platform you want
+to run your app on.
 
 ## Deploying Apps with `{golem}`
 
-The `dev/03_deploy.R` file contains function for deploying on various platforms. 
+The `dev/03_deploy.R` file contains functions for deployment on various platforms. 
 
-### RStudio Products
+### Posit Products
 
 ```{r}
 golem::add_rstudioconnect_file()
@@ -63,12 +70,15 @@ golem::add_shinyappsio_file()
 golem::add_shinyserver_file()
 ```
 
+For Git backed deployment on Posit (for [details](https://docs.posit.co/connect/user/git-backed/#linking-git-to-posit-connect)
+a `manifest.json` file is required which can be added (or updated) via:
+```{r}
+rsconnect::writeManifest()
+```
 
 ### Docker 
 
-#### without using {renv}
-
-
+#### Without using `{renv}`
 
 ```{r}
 # If you want to deploy via a generic Dockerfile
@@ -81,10 +91,7 @@ golem::add_dockerfile_shinyproxy()
 golem::add_dockerfile_heroku()
 ```
 
-#### using {renv}
-
-
-#### CASE 1 : you didn't use renv during developpment process
+#### Using `{renv}` - CASE 1 : you didn't use renv during development process
 
 
 > this functions will create a "deploy" folder containing : 
@@ -98,8 +105,7 @@ deploy/
 \-- renv.lock.prod
 ```
 
-then follow the README file
-
+then follow the `README` file.
 
 ```{r}
 # If you want to deploy via a generic Dockerfile
@@ -109,7 +115,8 @@ golem::add_dockerfile_with_renv(output_dir = "deploy")
 golem::add_dockerfile_with_renv_shinyproxy(output_dir = "deploy")
 ```
 
-If you would like to use {renv} during developpement, you can init a renv.lock file with
+If you would like to use `{renv}` during development, you can init a 
+`renv.lock` file with
 
 ```{r}
 attachment::create_renv_for_dev(dev_pkg = c(
@@ -127,21 +134,17 @@ attachment::create_renv_for_dev(dev_pkg = c(
   "golem"
 ))
 ```
-an activate {renv} with
+
+and activate `{renv}` with
 
 ```{r}
 renv::activate()
 ```
 
 
-
-
-
-#### CASE 2 : you already have a renv.lock file for your project
-
+#### Using `{renv}` - CASE 2: you already have a `renv.lock` file for your project
 
 ```{r}
-
 # If you want to deploy via a generic Dockerfile
 golem::add_dockerfile_with_renv(output_dir = "deploy", lockfile = "renv.lock")
 
@@ -160,4 +163,4 @@ deploy/
 \-- renv.lock.prod
 ```
 
-then follow the README file
+then follow the `README` file.


### PR DESCRIPTION
Fix #1031 

Just to make sure I do not miss anything @jdavis-EliLilly , is it just this one-liner here?
https://github.com/ThinkR-open/golem/blob/1ce2d5c28f287c2da08a6358c8160d88e8c46af1/inst/shinyexample/dev/03_deploy.R#L40-L42

From the documentation I understand that `rsconnect::writeManifest()` is for repeated usage, similar to `rsconnect::deployApp()` for repeated deployment (whereas the other functions in the file are usually called once for file creation only). So I would think this is a reasonable place for the `rsconnect::writeManifest()` call, or?