### PR TITLE
Fix 1065 to improve code coverage for `with_opt.R` to 100%

### DIFF
--- a/tests/testthat/test-maintenance.R
+++ b/tests/testthat/test-maintenance.R
@@ -1,4 +1,0 @@
-test_that("test maintenance_page", {
-  html <- maintenance_page()
-  expect_true(inherits(html, c("html_document", "shiny.tag.list", "list")))
-})

--- a/tests/testthat/test-with_opt.R
+++ b/tests/testthat/test-with_opt.R
@@ -1,42 +1,5 @@
-test_that("maintenance page works directly and via with_golem_options()", {
-  path_dummy_golem <- tempfile(pattern = "dummygolem")
-  create_golem(
-    path = path_dummy_golem,
-    open = FALSE
-  )
-  with_dir(
-    path_dummy_golem,
-    {
-      # 1. Test the maintenance feature directly
-      html <- maintenance_page()
-      expect_true(inherits(html, c("html_document", "shiny.tag.list", "list")))
-
-      # 2. Test the maintenance feature with setting/unsetting the option
-      Sys.setenv("GOLEM_MAINTENANCE_ACTIVE" = FALSE)
-      app_options_no_maintenance <- run_app()
-      Sys.setenv("GOLEM_MAINTENANCE_ACTIVE" = TRUE)
-      app_options_maintenance <- run_app()
-      # -> should produce different App objects as options are set differently
-      expect_false(
-        isTRUE(
-          all.equal(
-            app_options_maintenance,
-            app_options_no_maintenance
-          )
-        )
-      )
-      Sys.setenv("GOLEM_MAINTENANCE_ACTIVE" = FALSE)
-      app_options_maintenance <- run_app()
-      # -> should produce the same App object as options are set equally
-      expect_equal(
-        app_options_maintenance,
-        app_options_no_maintenance
-      )
-    }
-  )
-})
 test_that(
-  "with_golem_options() disables 'print'-flag on Posit platforms",
+  "maintenance page works directly and via with_golem_options()",
   {
     path_dummy_golem <- tempfile(pattern = "dummygolem")
     create_golem(
@@ -46,34 +9,102 @@ test_that(
     with_dir(
       path_dummy_golem,
       {
-        # generate a run_app file with 'print = TRUE'
-        # run_app_with_print_FALSE <- readLines("R/run_app.R")
-        # last_lines <- run_app_with_print_FALSE[26:28]
-        # last_lines[1] <- "    golem_opts = list(...),"
-        # run_app_with_print_TRUE <- c(
-        #   run_app_with_print_FALSE[-c(26:28)],
-        #   last_lines[1],
-        #   "    print = FALSE,", last_lines[2:3])
-        # writeLines(run_app_with_print_TRUE, "R/run_app.R")
-        # source("R/run_app.R")
-        app_print_true <- run_app()
-        # generate an app with print = FALSE by setting the port
+        # 1. Test the maintenance feature directly
+        html <- maintenance_page()
+        expect_true(inherits(html, c("html_document", "shiny.tag.list", "list")))
+
+        # 2. Test the maintenance feature with setting/unsetting the option
+        Sys.setenv("GOLEM_MAINTENANCE_ACTIVE" = FALSE)
+        app_options_no_maintenance <- run_app()
+        Sys.setenv("GOLEM_MAINTENANCE_ACTIVE" = TRUE)
+        app_options_maintenance <- run_app()
+        # -> should produce different App objects as options are set differently
+        expect_false(
+          isTRUE(
+            all.equal(
+              app_options_maintenance,
+              app_options_no_maintenance
+            )
+          )
+        )
+        Sys.setenv("GOLEM_MAINTENANCE_ACTIVE" = FALSE)
+        app_options_maintenance <- run_app()
+        # -> should produce the same App object as options are set equally
+        expect_equal(
+          app_options_maintenance,
+          app_options_no_maintenance
+        )
+      }
+    )
+  }
+)
+test_that(
+  "with_golem_options() disables 'print'-flag on Posit for SHINY_PORT",
+  {
+    path_dummy_golem <- tempfile(pattern = "dummygolem")
+    create_golem(
+      path = path_dummy_golem,
+      open = FALSE
+    )
+    with_dir(
+      path_dummy_golem,
+      {
+        # I. Test disabling the 'print'-flag on Posit for SHINY_PORT set
+        # I.A save output with "print = FALSE" as the testing value
+        app_print_false <- run_app()
+        # I.B generate a run_app.R file with 'print = TRUE'
+        run_app_with_print_FALSE <- readLines("R/run_app.R")
+        last_lines <- run_app_with_print_FALSE[26:28]
+        last_lines[1] <- "    golem_opts = list(...),"
+        run_app_with_print_TRUE <- c(
+          run_app_with_print_FALSE[-c(26:28)],
+          last_lines[1],
+          "    print = TRUE,",
+          last_lines[2:3]
+        )
+        writeLines(run_app_with_print_TRUE, "R/run_app.R")
+        # I.B source a new definition for run_app()
+        source("R/run_app.R")
+        # I.B check that generating app with "SHINY_PORT" sets 'print = FALSE'
         Sys.setenv("SHINY_PORT" = "123")
+        # the following code would run "run_app()" with print=TRUE but the
+        # environment variable "SHINY_PORT" is set. So the app should run with
+        # 'print=FALSE' which we check now:
         app_with_port <- run_app()
         expect_true(
           isTRUE(
             all.equal(
-              app_print_true,
+              app_print_false,
               app_with_port
             )
           )
         )
-        # # generate an app with print = TRUE by unsetting the port
+        # II. check that 'print=TRUE' works
+        # II.B override print.shiny.appobj inside the shiny pkg-namespace so
+        # print(app) inside with_golem_options() can be properly tested
+        print_s3_shiny_backup <- getFromNamespace("print.shiny.appobj", "shiny")
+        # change print.shiny.appobj method for testing purposes
+        print_s3_shiny_tmp_test <- function(app) {
+          print("Hello, golem!")
+        }
+        assignInNamespace(
+          "print.shiny.appobj",
+          print_s3_shiny_tmp_test,
+          ns = "shiny"
+        )
+        # II.C generate an app with 'print = TRUE' by unsetting the port and
+        # using the above updated run_app()
         Sys.setenv("SHINY_PORT" = "")
-        app_with_port <- run_app()
-        expect_equal(
-          app_print_true,
-          app_with_port
+        # check that print(app) i.e. 'print' is indeed TRUE
+        expect_output(
+          run_app(),
+          "Hello, golem!"
+        )
+        # Assign back the correct print-method to the shiny pkg-namespace
+        assignInNamespace(
+          "print.shiny.appobj",
+          print_s3_shiny_backup,
+          ns = "shiny"
         )
       }
     )
@@ -122,7 +153,7 @@ test_that(
           get_golem_options("country_02"),
           "germany"
         )
-        # II. assign global variable back and check that this reset is successful
+        # II. reset global variable and check that this reset is successful
         assignInNamespace(".globals", tmp_globals_backup, ns = "shiny")
         expect_null(getShinyOption("golem_options"))
         expect_null(get_golem_options())

--- a/tests/testthat/test-with_opt.R
+++ b/tests/testthat/test-with_opt.R
@@ -35,62 +35,98 @@ test_that("maintenance page works directly and via with_golem_options()", {
     }
   )
 })
-test_that("with_golem_options() disables 'print'-flag on Posit platforms", {
-  path_dummy_golem <- tempfile(pattern = "dummygolem")
-  create_golem(
-    path = path_dummy_golem,
-    open = FALSE
-  )
-  with_dir(
-    path_dummy_golem,
-    {
-    # generate a run_app file with 'print = TRUE'
-    # run_app_with_print_FALSE <- readLines("R/run_app.R")
-    # last_lines <- run_app_with_print_FALSE[26:28]
-    # last_lines[1] <- "    golem_opts = list(...),"
-    # run_app_with_print_TRUE <- c(
-    #   run_app_with_print_FALSE[-c(26:28)],
-    #   last_lines[1],
-    #   "    print = FALSE,", last_lines[2:3])
-    # writeLines(run_app_with_print_TRUE, "R/run_app.R")
-    # source("R/run_app.R")
-    app_print_true <- run_app()
-    # generate an app with print = FALSE by setting the port
-    Sys.setenv("SHINY_PORT" = "123")
-    app_with_port <- run_app()
-    expect_true(
-      isTRUE(
-        all.equal(
+test_that(
+  "with_golem_options() disables 'print'-flag on Posit platforms",
+  {
+    path_dummy_golem <- tempfile(pattern = "dummygolem")
+    create_golem(
+      path = path_dummy_golem,
+      open = FALSE
+    )
+    with_dir(
+      path_dummy_golem,
+      {
+        # generate a run_app file with 'print = TRUE'
+        # run_app_with_print_FALSE <- readLines("R/run_app.R")
+        # last_lines <- run_app_with_print_FALSE[26:28]
+        # last_lines[1] <- "    golem_opts = list(...),"
+        # run_app_with_print_TRUE <- c(
+        #   run_app_with_print_FALSE[-c(26:28)],
+        #   last_lines[1],
+        #   "    print = FALSE,", last_lines[2:3])
+        # writeLines(run_app_with_print_TRUE, "R/run_app.R")
+        # source("R/run_app.R")
+        app_print_true <- run_app()
+        # generate an app with print = FALSE by setting the port
+        Sys.setenv("SHINY_PORT" = "123")
+        app_with_port <- run_app()
+        expect_true(
+          isTRUE(
+            all.equal(
+              app_print_true,
+              app_with_port
+            )
+          )
+        )
+        # # generate an app with print = TRUE by unsetting the port
+        Sys.setenv("SHINY_PORT" = "")
+        app_with_port <- run_app()
+        expect_equal(
           app_print_true,
           app_with_port
         )
-      )
+      }
     )
-    # # generate an app with print = TRUE by unsetting the port
-    Sys.setenv("SHINY_PORT" = "")
-    app_with_port <- run_app()
-    expect_equal(
-      app_print_true,
-      app_with_port
-    )
-    }
-  )
   }
 )
-# test_that("with_golem_options() disables 'print'-flag on Posit platforms", {
-#   path_dummy_golem <- tempfile(pattern = "dummygolem")
-#   create_golem(
-#     path = path_dummy_golem,
-#     open = FALSE
-#   )
-#   with_dir(
-#     path_dummy_golem,
-#     {
-#       gol_opt_default <- get_golem_options()
-#       gol_opt_set     <- get_golem_options()
-#       expect_equal(gol_opt_default, gol_opt_set)
-#       options(golem.app.prod = FALSE)
-#     }
-#   )
-#   }
-# )
+test_that(
+  "get_golem_options() retrieves 'golem_options'",
+  {
+    path_dummy_golem <- tempfile(pattern = "dummygolem")
+    create_golem(
+      path = path_dummy_golem,
+      open = FALSE
+    )
+    with_dir(
+      path_dummy_golem,
+      {
+        # 0. Preparation:
+        # 0.A backup hidden variable '.global' from the shiny pkg-namespace
+        tmp_globals_backup <- getFromNamespace(".globals", "shiny")
+        # 0.B make a full clone of this variable (which is an environment)
+        tmp_globals_override <- as.environment(
+          as.list(
+            tmp_globals_backup,
+            all.names = TRUE
+          )
+        )
+        # 0.C mimick the existence of "golem_options" inside the clone
+        tmp_globals_override$options$golem_options$country_01 <- "france"
+        tmp_globals_override$options$golem_options$country_02 <- "germany"
+        # I Testing:
+        # I.A temporarily override ".globals" with the clone
+        assignInNamespace(".globals", tmp_globals_override, ns = "shiny")
+        # I.B test that get_golem_options() correctly retrieves "golem_options"
+        expect_equal(
+          get_golem_options(),
+          list(
+            country_01 = "france",
+            country_02 = "germany"
+          )
+        )
+        expect_equal(
+          get_golem_options("country_01"),
+          "france"
+        )
+        expect_equal(
+          get_golem_options("country_02"),
+          "germany"
+        )
+        # II. assign global variable back and check that this reset is successful
+        assignInNamespace(".globals", tmp_globals_backup, ns = "shiny")
+        expect_null(getShinyOption("golem_options"))
+        expect_null(get_golem_options())
+      }
+    )
+  }
+)

--- a/tests/testthat/test-with_opt.R
+++ b/tests/testthat/test-with_opt.R
@@ -1,0 +1,96 @@
+test_that("maintenance page works directly and via with_golem_options()", {
+  path_dummy_golem <- tempfile(pattern = "dummygolem")
+  create_golem(
+    path = path_dummy_golem,
+    open = FALSE
+  )
+  with_dir(
+    path_dummy_golem,
+    {
+      # 1. Test the maintenance feature directly
+      html <- maintenance_page()
+      expect_true(inherits(html, c("html_document", "shiny.tag.list", "list")))
+
+      # 2. Test the maintenance feature with setting/unsetting the option
+      Sys.setenv("GOLEM_MAINTENANCE_ACTIVE" = FALSE)
+      app_options_no_maintenance <- run_app()
+      Sys.setenv("GOLEM_MAINTENANCE_ACTIVE" = TRUE)
+      app_options_maintenance <- run_app()
+      # -> should produce different App objects as options are set differently
+      expect_false(
+        isTRUE(
+          all.equal(
+            app_options_maintenance,
+            app_options_no_maintenance
+          )
+        )
+      )
+      Sys.setenv("GOLEM_MAINTENANCE_ACTIVE" = FALSE)
+      app_options_maintenance <- run_app()
+      # -> should produce the same App object as options are set equally
+      expect_equal(
+        app_options_maintenance,
+        app_options_no_maintenance
+      )
+    }
+  )
+})
+test_that("with_golem_options() disables 'print'-flag on Posit platforms", {
+  path_dummy_golem <- tempfile(pattern = "dummygolem")
+  create_golem(
+    path = path_dummy_golem,
+    open = FALSE
+  )
+  with_dir(
+    path_dummy_golem,
+    {
+    # generate a run_app file with 'print = TRUE'
+    # run_app_with_print_FALSE <- readLines("R/run_app.R")
+    # last_lines <- run_app_with_print_FALSE[26:28]
+    # last_lines[1] <- "    golem_opts = list(...),"
+    # run_app_with_print_TRUE <- c(
+    #   run_app_with_print_FALSE[-c(26:28)],
+    #   last_lines[1],
+    #   "    print = FALSE,", last_lines[2:3])
+    # writeLines(run_app_with_print_TRUE, "R/run_app.R")
+    # source("R/run_app.R")
+    app_print_true <- run_app()
+    # generate an app with print = FALSE by setting the port
+    Sys.setenv("SHINY_PORT" = "123")
+    app_with_port <- run_app()
+    expect_true(
+      isTRUE(
+        all.equal(
+          app_print_true,
+          app_with_port
+        )
+      )
+    )
+    # # generate an app with print = TRUE by unsetting the port
+    Sys.setenv("SHINY_PORT" = "")
+    app_with_port <- run_app()
+    expect_equal(
+      app_print_true,
+      app_with_port
+    )
+    }
+  )
+  }
+)
+# test_that("with_golem_options() disables 'print'-flag on Posit platforms", {
+#   path_dummy_golem <- tempfile(pattern = "dummygolem")
+#   create_golem(
+#     path = path_dummy_golem,
+#     open = FALSE
+#   )
+#   with_dir(
+#     path_dummy_golem,
+#     {
+#       gol_opt_default <- get_golem_options()
+#       gol_opt_set     <- get_golem_options()
+#       expect_equal(gol_opt_default, gol_opt_set)
+#       options(golem.app.prod = FALSE)
+#     }
+#   )
+#   }
+# )


### PR DESCRIPTION
Fix #1065 

#### Done:

- [x] change filename: `{testthat}` style suggests "test-with_opt.R" as a file name for tests of functions from "R/with_opt.R" 7f5d6d2a19ff5f9ccf079e985e7df1c845c74c4a

- [x] improve tests for maintenance mode to see whether it works with setting options in a fresh golem 7f5d6d2a19ff5f9ccf079e985e7df1c845c74c4a

- [x] add tests for `SHINY_PORT` 7f5d6d2a19ff5f9ccf079e985e7df1c845c74c4a and 5d09b498e63051d883847b74c32b64a5b89858f0

- [x] `get_golem_options` is tested by temporarily altering `shiny:::.globals` variable 1b833327d016d0196b8b2ad715b9da82cd9a19ce

- [x] corner case with the `print=TRUE`-flag in `with_golem_options()` is tested by temporarily overwriting S3-method `shiny:::print.shiny.appobj()` 5d09b498e63051d883847b74c32b64a5b89858f0

To-Do / Note keeping:

Full coverage reached for file `R/with_opt.R`:
![image](https://github.com/ThinkR-open/golem/assets/36898027/9533fe0c-79c0-41a9-a4f5-5fcc3db145b2)

