### PR TITLE
feature: use codecov badge depending on the current git branch

### DIFF
--- a/.github/workflows/render-rmarkdown.yaml
+++ b/.github/workflows/render-rmarkdown.yaml
@@ -1,0 +1,38 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+
+# Controls when the action will run: for now dev and master
+on:
+  push:
+    branches: [master, dev]
+
+name: render-rmarkdown
+
+jobs:
+  render-rmarkdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    # Checks-out golem repo so the job can access it
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-renv@v2
+
+    # install CRAN packages used inside README.Rmd
+      - name: install required packages
+        run: Rscript -e 'install.packages(c("rmarkdown", "covr"))'
+    # Render READEME.md using rmarkdown
+      - name: render README
+        run: Rscript -e 'rmarkdown::render("README.Rmd", output_format = "md_document")'
+      - name: Render Rmarkdown files and Commit Results
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add README.md
+          git commit -m "Re-build README.md" || echo "No changes to commit"
+          git push origin || echo "No changes to commit"

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,23 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 
-[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html) [![R-CMD-check](https://github.com/ThinkR-open/golem/workflows/R-CMD-check/badge.svg)](https://github.com/ThinkR-open/golem/actions) [![Coverage status](https://codecov.io/gh/ThinkR-open/golem/branch/master/graph/badge.svg)](https://codecov.io/github/ThinkR-open/golem?branch=master) [![CRAN status](https://www.r-pkg.org/badges/version/golem)](https://cran.r-project.org/package=golem)
+```{r echo = FALSE}
+name_branch <- system("git symbolic-ref --short HEAD", intern = TRUE)
+link_to_branch_svg <- paste0(
+  "https://codecov.io/gh/ThinkR-open/golem/branch/",
+  name_branch,
+  "/graph/badge.svg")
+link_to_branch_html <- paste0(
+  "https://app.codecov.io/github/ThinkR-open/golem/tree/",
+  name_branch)
+```
+
+```{r, echo = FALSE, results = "asis"}
+cat('[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html)')
+cat('[![R-CMD-check](https://github.com/ThinkR-open/golem/workflows/R-CMD-check/badge.svg)](https://github.com/ThinkR-open/golem/actions)')
+cat(paste0("\n[![Coverage status](", link_to_branch_svg, ")](", link_to_branch_html, ")"))
+cat('[![CRAN status](https://www.r-pkg.org/badges/version/golem)](https://cran.r-project.org/package=golem)')
+```
 
  <!-- badges: end -->
 


### PR DESCRIPTION
Fix #1086 

This PR implements a changing codecov status badge dependening on the current git-branch of the `{golem}` projects.

`README.Rmd` is altered to programmatically retrieve the current git branch and alter links to point to the correct coverage results from https://about.codecov.io/ for the svg-images and webpages.
