### PR TITLE
hotfix: remove `return(invisible(file))`

### DIFF
--- a/R/run_dev.R
+++ b/R/run_dev.R
@@ -13,7 +13,7 @@
 #' reloading the package in a clean `R` environment before running the app etc.
 #'
 #' @param file String with (relative) file path to a `run_dev.R`-file
-#' @param install_required_packages Boolean; if `TRUE` install the packages 
+#' @param install_required_packages Boolean; if `TRUE` install the packages
 #'     used in `run_dev.R`-file
 #' @param save_all Boolean; if `TRUE` saves all open files before sourcing
 #'     `file`
@@ -59,11 +59,10 @@ run_dev <- function(
     to_install <- attachment::att_from_rscript(path = try_dev)
     install_dev_deps(dev_deps = to_install, force_install = install_required_packages)
   }
-  
+
   eval(
     parse(
       text = run_dev_lines
     )
   )
-  return(invisible(file))
 }


### PR DESCRIPTION
Fix #1090 

Removing this line works but I have to admit I am not entirely sure why. 

I only remember that I added it some time ago in a PR as I found it innocuous enough to not even be tested (there is some convention going on that side-effect functions should return invisibly ...)