### PR TITLE
style: remove redundant whitespace

### DIFF
--- a/inst/shinyexample/man/run_app.Rd
+++ b/inst/shinyexample/man/run_app.Rd
@@ -33,7 +33,7 @@ request to determine whether the \code{ui} should be used to handle the
 request. Note that the entire request path must match the regular
 expression in order for the match to be considered successful.}
 
-\item{...}{arguments to pass to golem_opts. 
+\item{...}{arguments to pass to golem_opts.
 See `?golem::get_golem_options` for more details.}
 }
 \description{


### PR DESCRIPTION
This PR fixes the white-space to prohibit the additional commit of the exact same file.

#### Issue
In a fresh golem `man/run_app.Rd` requires an additional commit after `devtools::document()` is called.

This is due to a white-space issue in the golem example, which looks like so:

![redundant-whitespace](https://github.com/ThinkR-open/golem/assets/36898027/015c4277-0f8f-498b-a510-b8d1714b2b91)


#### Fix

see commit
