### PR TITLE
fix: user-supplied lockfiles are correctly copied

### DIFF
--- a/R/add_dockerfiles_renv.R
+++ b/R/add_dockerfiles_renv.R
@@ -80,7 +80,7 @@ add_dockerfile_with_renv_ <- function(
 
   my_dock <- dockerfiler_Dockerfile()$new(FROM = tolower(tolower(paste0(golem::get_golem_name(), "_base"))))
 
-  my_dock$COPY("renv.lock.prod", "renv.lock")
+  my_dock$COPY(lockfile, "renv.lock")
 
   my_dock$RUN("R -e 'renv::restore()'")
 


### PR DESCRIPTION
Addresses https://github.com/ThinkR-open/golem/issues/1099

I think I found the line causing issues with supplying your own renv.lock file. Unless the idea is that any user-supplied lockfile MUST be called renv.lock.prod -- then disregard this. 