### PR TITLE
Fix: bypass unused argument error with higher attachment version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     utils,
     yaml
 Suggests:
-    attachment (>= 0.2.5),
+    attachment (>= 0.3.2),
     cli (>= 2.0.0),
     covr,
     crayon,


### PR DESCRIPTION
#### Fix:


Set minimum `{attachment}` version to `0.3.2` (maybe `0.4.0` is better since on CRAN but `0.3.2` works see below) in `Suggests:` -> `DESCRIPTION`.


#### Context:

Increase attachment pkg version because of #1103 which reports unused argument error for attachment version `0.3.0`:

```r
Error in renv::snapshot(packages = pkg_list, lockfile = output, prompt = FALSE, :
unused argument (check_if_suggests_is_installed = ..1)
```

On my platform with attachment version 

```r
> packageVersion("attachment")
[1] ‘0.3.1.9002’
```

No error was produced:
<details>

<summary> After running golem::add_dockerfile_with_renv()</summary>

```r
> golem::add_dockerfile_with_renv(output_dir = "./inst")
✔ Setting active project to '/home/.../TestGolem'
✔ Adding '^\\./inst$' to '.Rbuildignore'
You set `document = TRUE` and you did not pass your own renv.lock file,
as a consequence {golem} will use `attachment::att_amend_desc()` to update your 
DESCRIPTION file before creating the renv.lock file

you can set `document = FALSE` to use your actual DESCRIPTION file,
or pass you own renv.lock to use, using the `lockfile` parameter

In any case be sure to have no Error or Warning at `devtools::check()`
Updating TestGolem documentation
ℹ Loading TestGolem
Writing NAMESPACE
Writing NAMESPACE
ℹ Loading TestGolem
All required packages are installed
✔ create renv.lock at ./inst/renv.lock.prod
NOTE: Dependency discovery took 11 seconds during snapshot.
Consider using .renvignore to ignore files -- see `?dependencies` for more information.
Use `renv::settings$snapshot.type("all")` to disable dependency discovery during snapshot.
The following package(s) will be updated in the lockfile:

# CRAN ===============================
- R6            [* -> 2.5.1]
- Rcpp          [* -> 1.0.11.1]
- attempt       [* -> 0.3.1]
- base64enc     [* -> 0.1-3]
- bslib         [* -> 0.5.0]
- cachem        [* -> 1.0.8]
- cli           [* -> 3.6.1]
- commonmark    [* -> 1.9.0]
- config        [* -> 0.3.1]
- crayon        [* -> 1.5.2]
- digest        [* -> 0.6.33]
- ellipsis      [* -> 0.3.2]
- fontawesome   [* -> 0.5.1]
- fs            [* -> 1.6.3]
- glue          [* -> 1.6.2]
- golem         [* -> 0.4.12]
- here          [* -> 1.0.1]
- htmltools     [* -> 0.5.5]
- httpuv        [* -> 1.6.11]
- jquerylib     [* -> 0.1.4]
- jsonlite      [* -> 1.8.7]
- later         [* -> 1.3.1]
- lifecycle     [* -> 1.0.3]
- magrittr      [* -> 2.0.3]
- memoise       [* -> 2.0.1]
- mime          [* -> 0.12]
- promises      [* -> 1.2.0.1]
- rappdirs      [* -> 0.3.3]
- remotes       [* -> 2.4.2]
- rlang         [* -> 1.1.1]
- rprojroot     [* -> 2.0.3]
- sass          [* -> 0.4.7]
- shiny         [* -> 1.7.4.1]
- sourcetools   [* -> 0.1.7-1]
- withr         [* -> 2.5.0]
- xtable        [* -> 1.8-4]
- yaml          [* -> 2.3.7]

# GitHub =============================
- fastmap       [* -> r-lib/fastmap@HEAD]

The version of R recorded in the lockfile will be updated:
- R             [* -> 4.3.1]

* Lockfile written to './inst/renv.lock.prod'.
ℹ Please wait while we compute system requirements...
Fetching system dependencies for 38 package records.
✔ Done
✔  checking for file ‘/home/.../TestGolem/DESCRIPTION’ ...
─  preparing ‘TestGolem’:
✔  checking DESCRIPTION meta-information ...
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
   Removed empty directory ‘TestGolem/tests/testthat’
─  building ‘TestGolem_0.0.0.9000.tar.gz’
   
✔  ./inst/TestGolem_0.0.0.9000.tar.gz created.
Warning message:
In dir.create(output_dir) : './inst' already exists
```
</details>
