### PR TITLE
Fix 1121 broken use readme test

### DIFF
--- a/tests/testthat/test-use_readme.R
+++ b/tests/testthat/test-use_readme.R
@@ -27,7 +27,6 @@ test_that("check_overwrite works", {
 
 test_that("use_readme_rmd works", {
   withr::with_dir(pkg, {
-    skip_if_not(interactive())
       expect_true(
         use_readme_rmd(
           open = FALSE,
@@ -39,6 +38,5 @@ test_that("use_readme_rmd works", {
       expect_true(
         file.exists("README.Rmd")
       )
-      devtools:::build_readme()
   })
 })

--- a/tests/testthat/test-use_readme.R
+++ b/tests/testthat/test-use_readme.R
@@ -23,6 +23,12 @@ test_that("check_overwrite works", {
     check_overwrite(FALSE, golem_sys("utils/empty_readme.Rmd")),
     "README.Rmd already exists. Set `overwrite = TRUE` to overwrite."
   )
+  # Check if file exists
+  expect_true(file.exists(golem_sys("utils/empty_readme.Rmd")))
+  # Remove file via check_overwrite setting overwrite=TRUE
+  check_overwrite(TRUE, golem_sys("utils/empty_readme.Rmd"))
+  # Check that file is indeed removed
+  expect_false(file.exists(golem_sys("utils/empty_readme.Rmd")))
 })
 
 test_that("use_readme_rmd works", {


### PR DESCRIPTION
Fix #1121 

Make all test for `test-use_readme.R` pass successfully in non-interactive mode.

Additionally, test a previously untested corner case.

Improves codecov for `use_readme.R` from 34.29% to 100% 