### PR TITLE
Fix 1068 remove old usethis funcs

### DIFF
--- a/inst/shinyexample/dev/02_dev.R
+++ b/inst/shinyexample/dev/02_dev.R
@@ -74,14 +74,6 @@ usethis::use_github_action_check_full()
 # Add action for PR
 usethis::use_github_action_pr_commands()
 
-# Travis CI
-usethis::use_travis()
-usethis::use_travis_badge()
-
-# AppVeyor
-usethis::use_appveyor()
-usethis::use_appveyor_badge()
-
 # Circle CI
 usethis::use_circleci()
 usethis::use_circleci_badge()

--- a/vignettes/b_dev.Rmd
+++ b/vignettes/b_dev.Rmd
@@ -155,8 +155,6 @@ About [package Vignette](https://r-pkgs.org/vignettes.html).
 ### Code coverage
 
 ```{r}
-usethis::use_travis()
-usethis::use_appveyor()
 usethis::use_coverage()
 ```
 

--- a/vignettes/b_dev.Rmd
+++ b/vignettes/b_dev.Rmd
@@ -27,7 +27,7 @@ knitr::opts_chunk$set(
 
 Now that you're all set with your project init, time to move to development!
 
-App development should happen through the `dev/02_dev.R` file, which contains common commands for developing. 
+App development should happen through the `dev/02_dev.R` file, which contains common commands for developing.
 
 ## Launching the app
 
@@ -39,7 +39,7 @@ To run the app, go to the `dev/run_dev.R` file, and run the all thing.
 
 You can use `attachment::att_amend_desc()` to parse the code in your `.R` files, detect `@import` `@importFrom` and `::`, and fill your `DESCRIPTION` accordingly.
 
-Note that the `{attachment}` package should be installed on your machine. 
+Note that the `{attachment}` package should be installed on your machine.
 
 ```{r}
 attachment::att_amend_desc()
@@ -77,7 +77,7 @@ mod_my_first_module_server <- function(input, output, session) {
 
 At the end of the file, you will find a piece of code that has to be copied and pasted inside your UI and server functions.
 
-## Add function files 
+## Add function files
 
 ```{r}
 golem::add_fct("helpers")
@@ -97,7 +97,7 @@ golem::add_css_file("custom")
 golem::add_sass_file("custom")
 ```
 
-Note: While the general philosophy of `{golem}` is being based on the idea that you're building a package, these functions can be used outside of a `{golem}` project. 
+Note: While the general philosophy of `{golem}` is being based on the idea that you're building a package, these functions can be used outside of a `{golem}` project.
 
 Note that you can also download external CSS and JavaScript files with:
 
@@ -106,14 +106,14 @@ golem::use_external_css_file(url = "url", name = "your_provided_name")
 golem::use_external_js_file(url = "url", name = "your_provided_name")
 ```
 
-The above has the effect of downloading the file at the specified url and giving it a provided name. If the intent is to use a CDN hosted CSS/JS file then manually add the tag - `tags$script(src = "source_of_ur_css/js")` in the function `golem_add_external_resources` in file `app-ui.R`. 
+The above has the effect of downloading the file at the specified url and giving it a provided name. If the intent is to use a CDN hosted CSS/JS file then manually add the tag - `tags$script(src = "source_of_ur_css/js")` in the function `golem_add_external_resources` in file `app-ui.R`.
 The tag can be added inside the `tags$head(...)` if the intent is to load the  js/css file in the `<head>` of the document or outside it if it is intended in the `<body>`.
 
 ### Adding these external resources to your app
 
-You can add any external resource into `inst/app/www`. 
+You can add any external resource into `inst/app/www`.
 
-JavaScript and CSS are automatically linked in the `golem_add_external_resources()` function. If you add other resources (example images), you can link them in the app with the `www` prefix: 
+JavaScript and CSS are automatically linked in the `golem_add_external_resources()` function. If you add other resources (example images), you can link them in the app with the `www` prefix:
 
 ```{r}
 tags$img(src = "www/my.png")
@@ -123,7 +123,7 @@ You can also list here the use of other packages, for example `useShinyalert()` 
 
 ### Add a data-raw folder
 
-If you have data in your package: 
+If you have data in your package:
 
 ```{r}
 usethis::use_data_raw()
@@ -160,7 +160,7 @@ usethis::use_coverage()
 
 ## Using `{golem}` dev functions
 
-There's a series of tools to make your app behave differently whether it's in dev or prod mode. Notably, the `app_prod()` and `app_dev()` function tests for `options( "golem.app.prod")` (or return TRUE if this option doesn't exist). 
+There's a series of tools to make your app behave differently whether it's in dev or prod mode. Notably, the `app_prod()` and `app_dev()` function tests for `options( "golem.app.prod")` (or return TRUE if this option doesn't exist).
 
 Setting this options at the beginning of your dev process allows to make your app behave in a specific way when you are in dev mode. For example, printing message to the console with `cat_dev()`.
 
@@ -171,7 +171,7 @@ options("golem.app.prod" = FALSE)
 golem::cat_dev("hey\n")
 ```
 
-You can then make any function being "dev-dependent" with the `make_dev()` function: 
+You can then make any function being "dev-dependent" with the `make_dev()` function:
 
 ```{r eval = TRUE}
 log_dev <- golem::make_dev(log)


### PR DESCRIPTION
Fix #1068 

- 6b698e19683726d79c27e3b212c16bd3b372a9da: remove lines as requested per issue
- 6c0e24202e6f073c4b8e33299f3ea7ef64971e0f: update vignette (removing corresponding entries)
- 0bf456c7b85769b15df9b1cbe59dc5fd6d692257: remove some annoying whitespaces in the previous docfile

## Note:

as `DESCRIPTION` has `usethis (>= 1.6.0)` there is probably no need for a deprecation note or something like that..