### PR TITLE
Silence one of the duplicated "Loading" messages from `run_dev()`

### DIFF
--- a/R/bootstrap_pkgload.R
+++ b/R/bootstrap_pkgload.R
@@ -20,7 +20,7 @@ pkgload_load_all <- function(
   export_imports = export_all,
   helpers = TRUE,
   attach_testthat = uses_testthat(path),
-  quiet = NULL,
+  quiet = TRUE,
   recompile = FALSE,
   warn_conflicts = TRUE
 ) {


### PR DESCRIPTION
In `pkgload_load_all()`, I changed the default value of `quiet` to `TRUE`, suppressing the output from `pkgload::load_all()`.

PR stems from https://github.com/ThinkR-open/golem/issues/1191. 