### PR TITLE
Update tests to not make strong assumptions about `actionButton()`'s HTML markup

### DIFF
--- a/inst/utils/test-golem_utils_ui.R
+++ b/inst/utils/test-golem_utils_ui.R
@@ -167,21 +167,12 @@ test_that("Test undisplay works", {
 		"go_filter",
 		"go"
 	)
-	expect_s3_class(
-		b,
-		"shiny.tag"
-	)
 	expect_equal(
-		as.character(b),
-		'<button id="go_filter" type="button" class="btn btn-default action-button">go</button>'
-	)
-	b_undisplay <- undisplay(b)
-	expect_s3_class(b, "shiny.tag")
-	expect_equal(
-		as.character(
-			b_undisplay
+		htmltools::tagGetAttribute(
+			undisplay(b),
+			"style"
 		),
-		'<button id="go_filter" type="button" class="btn btn-default action-button" style="display: none;">go</button>'
+		"display: none;"
 	)
 
 	c <- shiny::tags$p(


### PR DESCRIPTION
Hello, I'm a core contributor to Shiny, and this PR is in anticipation for https://github.com/rstudio/shiny/pull/4249, where we plan on making changes to the HTML markup that `actionButton()` produces, which will break these tests of `undisplay()`'s logic.

I've made a minimal change to still test the logic you're aiming to test, but without making such strong assumptions about the markup that `actionButton()` generates. It would be great if golem could make a more extensive pass through tests (and utility functions) to not be so tightly coupled with Shiny's HTML markup generation. Some tools you can use to combat this include `{htmltools}`'s `tagGetAttribute()`, `tagSetAttributes()`, `tagQuery()`, etc. You may also consider [snapshot testing](https://testthat.r-lib.org/articles/snapshotting.html) for tests that truly do want to make assumptions about markup generation beyond your control.