### PR TITLE
implement non-interactive flow for create_if_needed()

### DIFF
--- a/R/add_r_files.R
+++ b/R/add_r_files.R
@@ -39,7 +39,8 @@ add_r_files <- function(
 
 	dir_created <- create_if_needed(
 		"R",
-		type = "directory"
+		type = "directory",
+		warn_if_exists = FALSE
 	)
 
 	if (!dir_created) {

--- a/R/modules_fn.R
+++ b/R/modules_fn.R
@@ -85,7 +85,8 @@ add_module <- function(
 			golem_wd,
 			"R"
 		),
-		type = "directory"
+		type = "directory",
+		warn_if_exists = FALSE
 	)
 
 	if (!dir_created) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -430,3 +430,39 @@ signal_arg_is_deprecated <- function(
 		)
 	}
 }
+
+#' Sanitize R names
+#'
+#' Convert a string to a valid R name for functions and variables
+#'
+#' @param name character string to sanitize
+#' @return character string with a valid R name
+#' @noRd
+sanitize_r_name <- function(name) {
+	if (is.na(name) || nchar(name) == 0) {
+		return("unnamed")
+	}
+
+	# Convert to lowercase and replace spaces with underscores
+	name <- tolower(name)
+	name <- gsub("[[:space:]]+", "_", name)
+
+	# Replace any non-alphanumeric characters with underscores
+	name <- gsub("[^a-zA-Z0-9_]", "_", name)
+
+	# Remove leading/trailing underscores and consolidate multiple underscores
+	name <- gsub("^_+|_+$", "", name)
+	name <- gsub("_+", "_", name)
+
+	# If name starts with a number, prefix with 'x'
+	if (grepl("^[0-9]", name)) {
+		name <- paste0("x", name)
+	}
+
+	# If name is empty after cleaning, use "unnamed"
+	if (nchar(name) == 0) {
+		name <- "unnamed"
+	}
+
+	return(name)
+}

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -15,7 +15,9 @@ test_that("rlang_is_interactive() works", {
 })
 
 test_that("create_if_needed creates a file if required", {
-	expect_error(
+	# Test: Non-interactive mode should now succeed and create the file
+	temp_file <- tempfile()
+	expect_true(
 		testthat::with_mocked_bindings(
 			rlang_is_interactive = function() {
 				return(
@@ -24,11 +26,13 @@ test_that("create_if_needed creates a file if required", {
 			},
 			code = {
 				create_if_needed(
-					tempfile()
+					temp_file
 				)
 			}
 		)
 	)
+	expect_true(file.exists(temp_file))
+	unlink(temp_file)
 	expect_false(
 		testthat::with_mocked_bindings(
 			rlang_is_interactive = function() {
@@ -487,5 +491,61 @@ test_that("signal_path_is_deprecated works", {
 			)
 		},
 		regexp = "mons"
+	)
+})
+
+test_that("sanitize_r_name works correctly", {
+	# Test spaces to underscores
+	expect_equal(
+		golem:::sanitize_r_name("ma fonction"),
+		"ma_fonction"
+	)
+
+	# Test special characters
+	expect_equal(
+		golem:::sanitize_r_name("my-special@function!"),
+		"my_special_function"
+	)
+
+	# Test uppercase to lowercase
+	expect_equal(
+		golem:::sanitize_r_name("UPPERCASE Function Name"),
+		"uppercase_function_name"
+	)
+
+	# Test leading number
+	expect_equal(
+		golem:::sanitize_r_name("123test"),
+		"x123test"
+	)
+
+	# Test multiple underscores consolidation
+	expect_equal(
+		golem:::sanitize_r_name("test___multiple___underscores"),
+		"test_multiple_underscores"
+	)
+
+	# Test leading/trailing underscores removal
+	expect_equal(
+		golem:::sanitize_r_name("_test_function_"),
+		"test_function"
+	)
+
+	# Test empty name
+	expect_equal(
+		golem:::sanitize_r_name(""),
+		"unnamed"
+	)
+
+	# Test NA name
+	expect_equal(
+		golem:::sanitize_r_name(NA_character_),
+		"unnamed"
+	)
+
+	# Test already valid name
+	expect_equal(
+		golem:::sanitize_r_name("valid_name"),
+		"valid_name"
 	)
 })


### PR DESCRIPTION
implements #1154 

I think the correct approach in non-interactive mode should be:

1. check if the file/dir exists
2. if it does not exist, create it
3. if it exists, refuse to overwrite and print a warning except is a new parameter is set to `overwrite = T` 
4. besides it, allow to hide warnings with an extra parameter (i.e., for testthat when we test overwriting)
