### PR TITLE
Fix 1219

### DIFF
--- a/R/add_r_files.R
+++ b/R/add_r_files.R
@@ -112,12 +112,12 @@ add_r_files <- function(
 	if (
 		name == "" &&
 			grepl(
-				"_.R$",
+				"_\\.R$",
 				tmp_name
 			)
 	) {
-		tmp_name <- gsub(
-			"_.R$",
+		tmp_name <- sub(
+			"_\\.R$",
 			".R",
 			tmp_name
 		)

--- a/R/add_r_files.R
+++ b/R/add_r_files.R
@@ -100,6 +100,7 @@ add_r_files <- function(
 			"_"
 		)
 	}
+
 	tmp_name <- paste0(
 		module,
 		ext,

--- a/R/add_r_files.R
+++ b/R/add_r_files.R
@@ -18,13 +18,13 @@ add_r_files <- function(
 		),
 		"pkg"
 	)
-	name <- sanitize_r_name(file_path_sans_ext(
-		name
-	))
-
 	check_name_length_is_one(
 		name
 	)
+
+	name <- sanitize_r_name(file_path_sans_ext(
+		name
+	))
 
 	old <- setwd(
 		fs_path_abs(

--- a/R/utils.R
+++ b/R/utils.R
@@ -328,6 +328,8 @@ check_name_length_is_one <- function(
 # Convert filename to lowercase and replace space/special with underscores
 # Similar to janitor::make_clean_names() but without the dependency
 sanitize_r_name <- function(name) {
+	transliterated <- iconv(name, to = "ASCII//TRANSLIT")
+	name[!is.na(transliterated)] <- transliterated[!is.na(transliterated)]
 	name <- tolower(name)
 	name <- gsub("[^a-z0-9_]", "_", name)
 	name <- gsub("^_+|_+$", "", name)

--- a/tests/testthat/test-add_r_files.R
+++ b/tests/testthat/test-add_r_files.R
@@ -234,6 +234,19 @@ test_that("add_fct sanitizes names correctly", {
 		expect_true(
 			any(grepl("x123function <- function", file_content3, fixed = TRUE))
 		)
+
+		# Name with accented latin characters
+
+		add_fct(
+			"éclair",
+			open = FALSE
+		)
+		expect_exists(
+			file.path(
+				"R",
+				"fct_eclair.R"
+			)
+		)
 	})
 })
 

--- a/tests/testthat/test-add_r_files.R
+++ b/tests/testthat/test-add_r_files.R
@@ -236,3 +236,43 @@ test_that("add_fct sanitizes names correctly", {
 		)
 	})
 })
+
+test_that("add_module with empty fct or utils does not create trailing underscore filenames", {
+	run_quietly_in_a_dummy_golem({
+		add_module(
+			"FixHumanity",
+			fct = "",
+			open = FALSE
+		)
+		expect_exists(
+			file.path(
+				"R",
+				"mod_FixHumanity_fct.R"
+			)
+		)
+		expect_false(
+			file.exists(file.path(
+				"R",
+				"mod_FixHumanity_fct_.R"
+			))
+		)
+
+		add_module(
+			"FixCompassion",
+			utils = "",
+			open = FALSE
+		)
+		expect_exists(
+			file.path(
+				"R",
+				"mod_FixCompassion_utils.R"
+			)
+		)
+		expect_false(
+			file.exists(file.path(
+				"R",
+				"mod_FixCompassion_utils_.R"
+			))
+		)
+	})
+})


### PR DESCRIPTION
Fix #1219 

handle fct = "" correctly; include upstream fix #1207 via #1215 for easier cherry picking

- brings in commit [`https://github.com/ThinkR-open/golem/pull/1215/commits/8e7c30ddda59e7d06f1a4ed6b43106db3043b0de`](https://github.com/ThinkR-open/golem/pull/1215/commits/8e7c30ddda59e7d06f1a4ed6b43106db3043b0de) to inherit the “sanitizer” logic. 

- adjust behavior so that fct = "" is treated as an empty string (not "unnamed"),

I dont like "unnamed" as internal name that propagates into golem-generated files; it seems to be difficult to handle as well; an empty func. name is probably just fine, as the original issue #1219 suggests.

