### PR TITLE
ci: bump deprecated GitHub Actions versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -10,11 +10,11 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: r-lib/actions/pr-fetch@v1
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/pr-fetch@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
       - name: Install dependencies
         run: Rscript -e 'install.packages(c("remotes", "roxygen2"))' -e 'remotes::install_deps(dependencies = TRUE)'
       - name: Document
@@ -25,7 +25,7 @@ jobs:
           git config --local user.name "GitHub Actions"
           git add man/\* NAMESPACE
           git commit -m 'Document'
-      - uses: r-lib/actions/pr-push@v1
+      - uses: r-lib/actions/pr-push@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
   style:
@@ -35,11 +35,11 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: r-lib/actions/pr-fetch@v1
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/pr-fetch@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
       - name: Install dependencies
         run: Rscript -e 'install.packages("styler")'
       - name: Style
@@ -50,6 +50,6 @@ jobs:
           git config --local user.name "GitHub Actions"
           git add \*.R
           git commit -m 'Style'
-      - uses: r-lib/actions/pr-push@v1
+      - uses: r-lib/actions/pr-push@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/render-rmarkdown-and-bump-version.yaml
+++ b/.github/workflows/render-rmarkdown-and-bump-version.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
     # Checks-out golem repo so the job can access it
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: r-lib/actions/setup-pandoc@v2


### PR DESCRIPTION
## Summary
Bump deprecated GitHub Actions to currently-supported majors. No behavioural change intended.

## Bumps applied (where present)
- `actions/checkout` v1/v2/v3 → v4
- `actions/cache` v1/v2/v3 → v4
- `actions/upload-artifact` v1/v2/v3 → v4
- `actions/download-artifact` v1.x/v2/v3 → v4
- `r-lib/actions/*` @v1 → @v2
- `r-lib/actions/setup-tinytex` @master → @v2

## Test plan
- [ ] CI runs green on this PR