### PR TITLE
feat: add replace arg to use_external_* wrappers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: golem
 Title: A Framework for Robust Shiny Applications
-Version: 0.6.0
+Version: 0.6.0.9000
 Authors@R: c(
     person("Colin", "Fay", , "contact@colinfay.me", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0001-7343-1846")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 > Notes: the # between parenthesis refers to the related issue on GitHub, and the @ refers to an external contributor solving this issue.
 
+# golem (development version)
+
+## New features
+
+- `use_external_js_file()`, `use_external_css_file()`,
+  `use_external_html_template()`, `use_external_file()` and
+  `use_bundled_html()` gain a `replace` argument. When `TRUE`, an existing
+  file (or bundle directory) at the target location is overwritten instead
+  of aborting (#819).
+
 # golem 0.5.1 to 0.6.0
 
 ## New features / user-visible changes

--- a/R/use_files_external.R
+++ b/R/use_files_external.R
@@ -14,9 +14,10 @@
 #' @param delete_zip Whether to delete the raw HTML zip after extraction. Use `"ask"` to prompt.
 #'   Only used by `use_bundled_html()` and by `use_external_html_template()`
 #'   when `url` points to a `.zip` archive.
-#' @param replace Boolean. If `TRUE`, an existing file at the target location is
-#'   overwritten. Defaults to `FALSE`, in which case the function aborts if the
-#'   target file already exists.
+#' @param replace Boolean. If `TRUE`, an existing file (or, for
+#'   `use_bundled_html()`, an existing bundle directory) at the target location
+#'   is overwritten. Defaults to `FALSE`, in which case the function aborts if
+#'   the target already exists.
 #'
 #' @note See `?htmltools::htmlTemplate` and `https://shiny.rstudio.com/articles/templates.html`
 #'     for more information about `htmlTemplate`.
@@ -31,9 +32,9 @@ use_external_js_file <- function(
 	golem_wd = get_golem_wd(),
 	dir = "inst/app/www",
 	open = FALSE,
-	replace = FALSE,
 	dir_create,
-	pkg
+	pkg,
+	replace = FALSE
 ) {
 	signal_arg_is_deprecated(
 		pkg,
@@ -70,9 +71,9 @@ use_external_css_file <- function(
 	golem_wd = get_golem_wd(),
 	dir = "inst/app/www",
 	open = FALSE,
-	replace = FALSE,
 	dir_create,
-	pkg
+	pkg,
+	replace = FALSE
 ) {
 	signal_arg_is_deprecated(
 		pkg,
@@ -109,10 +110,10 @@ use_external_html_template <- function(
 	golem_wd = get_golem_wd(),
 	dir = "inst/app/www",
 	open = FALSE,
-	replace = FALSE,
 	dir_create,
 	extract = c("ask", "yes", "no"),
-	delete_zip = c("ask", "yes", "no")
+	delete_zip = c("ask", "yes", "no"),
+	replace = FALSE
 ) {
 	if (!missing(dir_create)) {
 		cli_abort_dir_create()
@@ -160,9 +161,9 @@ use_external_file <- function(
 	golem_wd = get_golem_wd(),
 	dir = "inst/app/www",
 	open = FALSE,
-	replace = FALSE,
 	dir_create,
-	pkg
+	pkg,
+	replace = FALSE
 ) {
 	signal_arg_is_deprecated(
 		pkg,
@@ -199,9 +200,9 @@ use_bundled_html <- function(
 	golem_wd = get_golem_wd(),
 	dir = "inst/app/www",
 	open = FALSE,
-	replace = FALSE,
 	extract = c("ask", "yes", "no"),
-	delete_zip = c("ask", "yes", "no")
+	delete_zip = c("ask", "yes", "no"),
+	replace = FALSE
 ) {
 	extract <- match.arg(extract)
 	delete_zip <- match.arg(delete_zip)
@@ -223,7 +224,7 @@ use_bundled_html <- function(
 			sprintf("%s_bundle.zip", name_bundle)
 		)
 	}
-	check_file_exists(where_zip, replace = replace)
+	check_file_exists(where_zip, replace = replace, with_replace_hint = TRUE)
 	check_directory_exists(dir)
 
 	where_bundle <- fs_path(dir, name_bundle)

--- a/R/use_files_external.R
+++ b/R/use_files_external.R
@@ -14,6 +14,9 @@
 #' @param delete_zip Whether to delete the raw HTML zip after extraction. Use `"ask"` to prompt.
 #'   Only used by `use_bundled_html()` and by `use_external_html_template()`
 #'   when `url` points to a `.zip` archive.
+#' @param replace Boolean. If `TRUE`, an existing file at the target location is
+#'   overwritten. Defaults to `FALSE`, in which case the function aborts if the
+#'   target file already exists.
 #'
 #' @note See `?htmltools::htmlTemplate` and `https://shiny.rstudio.com/articles/templates.html`
 #'     for more information about `htmlTemplate`.
@@ -28,6 +31,7 @@ use_external_js_file <- function(
 	golem_wd = get_golem_wd(),
 	dir = "inst/app/www",
 	open = FALSE,
+	replace = FALSE,
 	dir_create,
 	pkg
 ) {
@@ -53,7 +57,8 @@ use_external_js_file <- function(
 		file_created_fun = after_creation_message_js,
 		golem_wd = golem_wd,
 		name = name,
-		open = open
+		open = open,
+		replace = replace
 	)
 }
 
@@ -65,6 +70,7 @@ use_external_css_file <- function(
 	golem_wd = get_golem_wd(),
 	dir = "inst/app/www",
 	open = FALSE,
+	replace = FALSE,
 	dir_create,
 	pkg
 ) {
@@ -90,7 +96,8 @@ use_external_css_file <- function(
 		file_created_fun = after_creation_message_css,
 		golem_wd = golem_wd,
 		name = name,
-		open = open
+		open = open,
+		replace = replace
 	)
 }
 
@@ -102,6 +109,7 @@ use_external_html_template <- function(
 	golem_wd = get_golem_wd(),
 	dir = "inst/app/www",
 	open = FALSE,
+	replace = FALSE,
 	dir_create,
 	extract = c("ask", "yes", "no"),
 	delete_zip = c("ask", "yes", "no")
@@ -118,6 +126,7 @@ use_external_html_template <- function(
 			golem_wd = golem_wd,
 			dir = dir,
 			open = open,
+			replace = replace,
 			extract = extract,
 			delete_zip = delete_zip
 		)
@@ -134,7 +143,8 @@ use_external_html_template <- function(
 		file_created_fun = after_creation_message_html_template,
 		golem_wd = golem_wd,
 		name = name,
-		open = open
+		open = open,
+		replace = replace
 	)
 }
 
@@ -150,6 +160,7 @@ use_external_file <- function(
 	golem_wd = get_golem_wd(),
 	dir = "inst/app/www",
 	open = FALSE,
+	replace = FALSE,
 	dir_create,
 	pkg
 ) {
@@ -175,7 +186,8 @@ use_external_file <- function(
 		file_created_fun = NULL,
 		golem_wd = golem_wd,
 		name = name,
-		open = open
+		open = open,
+		replace = replace
 	)
 }
 
@@ -187,6 +199,7 @@ use_bundled_html <- function(
 	golem_wd = get_golem_wd(),
 	dir = "inst/app/www",
 	open = FALSE,
+	replace = FALSE,
 	extract = c("ask", "yes", "no"),
 	delete_zip = c("ask", "yes", "no")
 ) {
@@ -210,18 +223,28 @@ use_bundled_html <- function(
 			sprintf("%s_bundle.zip", name_bundle)
 		)
 	}
-	check_file_exists(where_zip)
+	check_file_exists(where_zip, replace = replace)
 	check_directory_exists(dir)
 
 	where_bundle <- fs_path(dir, name_bundle)
-	if (fs_dir_exists(where_bundle) || fs_file_exists(where_bundle)) {
+	if (
+		!isTRUE(replace) &&
+			(fs_dir_exists(where_bundle) || fs_file_exists(where_bundle))
+	) {
 		cli_abort(
 			sprintf(
-				"%s already exists.\n\nYou can delete it with:\nunlink('%s', recursive = TRUE).",
+				"%s already exists.\n\nYou can delete it with:\nunlink('%s', recursive = TRUE).\n\nAlternatively, call this function again with `replace = TRUE`.",
 				where_bundle,
 				where_bundle
 			)
 		)
+	}
+	if (isTRUE(replace)) {
+		if (fs_dir_exists(where_bundle)) {
+			fs_dir_delete(where_bundle)
+		} else if (fs_file_exists(where_bundle)) {
+			fs_file_delete(where_bundle)
+		}
 	}
 
 	progress_id <- cli_progress_bar(

--- a/R/use_files_external_tools.R
+++ b/R/use_files_external_tools.R
@@ -94,6 +94,7 @@ perform_checks_and_download_if_everything_is_ok <- function(
 	golem_wd,
 	name,
 	open,
+	replace = FALSE,
 	pkg
 ) {
 	signal_arg_is_deprecated(
@@ -144,7 +145,8 @@ perform_checks_and_download_if_everything_is_ok <- function(
 		directory_to_download_to
 	)
 	check_file_exists(
-		where_to_download_to
+		where_to_download_to,
+		replace = replace
 	)
 	download_external(
 		url_to_download_from = url_to_download_from,

--- a/R/use_files_external_tools.R
+++ b/R/use_files_external_tools.R
@@ -146,7 +146,8 @@ perform_checks_and_download_if_everything_is_ok <- function(
 	)
 	check_file_exists(
 		where_to_download_to,
-		replace = replace
+		replace = replace,
+		with_replace_hint = TRUE
 	)
 	download_external(
 		url_to_download_from = url_to_download_from,

--- a/R/use_files_shared_tools.R
+++ b/R/use_files_shared_tools.R
@@ -47,7 +47,8 @@ check_directory_exists <- function(
 
 check_file_exists <- function(
 	where,
-	replace = FALSE
+	replace = FALSE,
+	with_replace_hint = FALSE
 ) {
 	if (isTRUE(replace)) {
 		return(invisible(NULL))
@@ -57,12 +58,17 @@ check_file_exists <- function(
 			where
 		)
 	) {
-		cli_abort(
-			sprintf(
-				"%s already exists.\n\nYou can delete it with:\nunlink('%s', recursive = TRUE).\n\nAlternatively, call this function again with `replace = TRUE`.",
-				where,
-				where
-			)
+		msg <- sprintf(
+			"%s already exists.\n\nYou can delete it with:\nunlink('%s', recursive = TRUE).",
+			where,
+			where
 		)
+		if (isTRUE(with_replace_hint)) {
+			msg <- paste0(
+				msg,
+				"\n\nAlternatively, call this function again with `replace = TRUE`."
+			)
+		}
+		cli_abort(msg)
 	}
 }

--- a/R/use_files_shared_tools.R
+++ b/R/use_files_shared_tools.R
@@ -46,8 +46,12 @@ check_directory_exists <- function(
 }
 
 check_file_exists <- function(
-	where
+	where,
+	replace = FALSE
 ) {
+	if (isTRUE(replace)) {
+		return(invisible(NULL))
+	}
 	if (
 		fs_file_exists(
 			where
@@ -55,7 +59,7 @@ check_file_exists <- function(
 	) {
 		cli_abort(
 			sprintf(
-				"%s already exists.\n\nYou can delete it with:\nunlink('%s', recursive = TRUE).",
+				"%s already exists.\n\nYou can delete it with:\nunlink('%s', recursive = TRUE).\n\nAlternatively, call this function again with `replace = TRUE`.",
 				where,
 				where
 			)

--- a/man/use_files.Rd
+++ b/man/use_files.Rd
@@ -18,9 +18,9 @@ use_external_js_file(
   golem_wd = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
-  replace = FALSE,
   dir_create,
-  pkg
+  pkg,
+  replace = FALSE
 )
 
 use_external_css_file(
@@ -29,9 +29,9 @@ use_external_css_file(
   golem_wd = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
-  replace = FALSE,
   dir_create,
-  pkg
+  pkg,
+  replace = FALSE
 )
 
 use_external_html_template(
@@ -40,10 +40,10 @@ use_external_html_template(
   golem_wd = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
-  replace = FALSE,
   dir_create,
   extract = c("ask", "yes", "no"),
-  delete_zip = c("ask", "yes", "no")
+  delete_zip = c("ask", "yes", "no"),
+  replace = FALSE
 )
 
 use_external_file(
@@ -52,9 +52,9 @@ use_external_file(
   golem_wd = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
-  replace = FALSE,
   dir_create,
-  pkg
+  pkg,
+  replace = FALSE
 )
 
 use_bundled_html(
@@ -63,9 +63,9 @@ use_bundled_html(
   golem_wd = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
-  replace = FALSE,
   extract = c("ask", "yes", "no"),
-  delete_zip = c("ask", "yes", "no")
+  delete_zip = c("ask", "yes", "no"),
+  replace = FALSE
 )
 
 use_internal_js_file(
@@ -119,13 +119,14 @@ use_internal_file(
 
 \item{open}{Should the created file be opened?}
 
-\item{replace}{Boolean. If \code{TRUE}, an existing file at the target location is
-overwritten. Defaults to \code{FALSE}, in which case the function aborts if the
-target file already exists.}
-
 \item{dir_create}{Creates the directory if it doesn't exist, default is \code{TRUE}.}
 
 \item{pkg}{Deprecated, please use golem_wd instead}
+
+\item{replace}{Boolean. If \code{TRUE}, an existing file (or, for
+\code{use_bundled_html()}, an existing bundle directory) at the target location
+is overwritten. Defaults to \code{FALSE}, in which case the function aborts if
+the target already exists.}
 
 \item{extract}{Whether to extract a downloaded HTML zip bundle. Use \code{"ask"} to prompt.
 Only used by \code{use_bundled_html()} and by \code{use_external_html_template()}

--- a/man/use_files.Rd
+++ b/man/use_files.Rd
@@ -18,6 +18,7 @@ use_external_js_file(
   golem_wd = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
+  replace = FALSE,
   dir_create,
   pkg
 )
@@ -28,6 +29,7 @@ use_external_css_file(
   golem_wd = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
+  replace = FALSE,
   dir_create,
   pkg
 )
@@ -38,6 +40,7 @@ use_external_html_template(
   golem_wd = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
+  replace = FALSE,
   dir_create,
   extract = c("ask", "yes", "no"),
   delete_zip = c("ask", "yes", "no")
@@ -49,6 +52,7 @@ use_external_file(
   golem_wd = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
+  replace = FALSE,
   dir_create,
   pkg
 )
@@ -59,6 +63,7 @@ use_bundled_html(
   golem_wd = get_golem_wd(),
   dir = "inst/app/www",
   open = FALSE,
+  replace = FALSE,
   extract = c("ask", "yes", "no"),
   delete_zip = c("ask", "yes", "no")
 )
@@ -113,6 +118,10 @@ use_internal_file(
 \item{dir}{Path to the dir where the file while be created.}
 
 \item{open}{Should the created file be opened?}
+
+\item{replace}{Boolean. If \code{TRUE}, an existing file at the target location is
+overwritten. Defaults to \code{FALSE}, in which case the function aborts if the
+target file already exists.}
 
 \item{dir_create}{Creates the directory if it doesn't exist, default is \code{TRUE}.}
 

--- a/tests/testthat/test-use_files.R
+++ b/tests/testthat/test-use_files.R
@@ -58,6 +58,51 @@ test_that("use_external_*_file works", {
 	})
 })
 
+test_that("use_external_*_file replaces existing files when replace = TRUE", {
+	run_quietly_in_a_dummy_golem({
+		testthat::with_mocked_bindings(
+			utils_download_file = function(url, there) {
+				file.create(there)
+			},
+			{
+				funs_and_ext <- list(
+					js = use_external_js_file,
+					css = use_external_css_file,
+					html = use_external_html_template,
+					txt = use_external_file
+				)
+				mapply(
+					function(fun, ext) {
+						url <- paste0("this.", ext)
+						# First call creates the file.
+						path_to_file <- fun(
+							url = url,
+							golem_wd = "."
+						)
+						expect_exists(path_to_file)
+						# Default behavior: error if the file already exists.
+						expect_error(
+							fun(url = url, golem_wd = "."),
+							"already exists"
+						)
+						# With replace = TRUE: no error, file is overwritten.
+						expect_no_error(
+							fun(
+								url = url,
+								golem_wd = ".",
+								replace = TRUE
+							)
+						)
+						expect_exists(path_to_file)
+					},
+					funs_and_ext,
+					names(funs_and_ext)
+				)
+			}
+		)
+	})
+})
+
 test_that("use_internal_*_file works", {
 	run_quietly_in_a_dummy_golem({
 		testthat::with_mocked_bindings(

--- a/tests/testthat/test-use_files.R
+++ b/tests/testthat/test-use_files.R
@@ -244,6 +244,68 @@ test_that("use_external_html_template keeps expected archive name when not extra
 	})
 })
 
+test_that("use_bundled_html replaces existing bundle dir or stale file", {
+	skip_if(Sys.which("zip") == "")
+	make_bundle <- function() {
+		src <- tempfile()
+		dir.create(src)
+		dir.create(file.path(src, "resume"))
+		writeLines("<html></html>", file.path(src, "resume", "index.html"))
+		zipfile <- tempfile(fileext = ".zip")
+		old <- setwd(src)
+		on.exit(setwd(old), add = TRUE)
+		utils::zip(zipfile = zipfile, files = "resume/index.html")
+		zipfile
+	}
+
+	run_in_bundled_html <- function() {
+		zipfile <- make_bundle()
+		testthat::with_mocked_bindings(
+			utils_download_file = function(url, where) {
+				file.copy(zipfile, where, overwrite = TRUE)
+			},
+			cli_progress_bar = function(...) 1,
+			cli_progress_update = function(...) invisible(NULL),
+			cli_progress_done = function(...) invisible(NULL),
+			{
+				use_bundled_html(
+					url = "https://example.com/template.zip",
+					name = "resume",
+					golem_wd = ".",
+					extract = "yes",
+					delete_zip = "yes",
+					replace = TRUE
+				)
+			}
+		)
+	}
+
+	# Case 1: existing bundle directory is removed and re-extracted.
+	run_quietly_in_a_dummy_golem({
+		bundle_dir <- "inst/app/www/resume"
+		dir.create(bundle_dir, recursive = TRUE)
+		writeLines("stale", file.path(bundle_dir, "old.txt"))
+		out <- run_in_bundled_html()
+		expect_equal(
+			as.character(out),
+			as.character(fs_path_abs(bundle_dir))
+		)
+		expect_true(file.exists(file.path(bundle_dir, "index.html")))
+		expect_false(file.exists(file.path(bundle_dir, "old.txt")))
+	})
+
+	# Case 2: stale file at the bundle path is removed before extraction.
+	run_quietly_in_a_dummy_golem({
+		bundle_path <- "inst/app/www/resume"
+		dir.create(dirname(bundle_path), recursive = TRUE, showWarnings = FALSE)
+		writeLines("stale", bundle_path)
+		expect_true(file.exists(bundle_path) && !dir.exists(bundle_path))
+		out <- run_in_bundled_html()
+		expect_true(dir.exists(bundle_path))
+		expect_true(file.exists(file.path(bundle_path, "index.html")))
+	})
+})
+
 test_that("use_external_html_template cancels and removes downloaded zip", {
 	run_quietly_in_a_dummy_golem({
 		out <- testthat::with_mocked_bindings(

--- a/tests/testthat/test-use_files_shared_tools.R
+++ b/tests/testthat/test-use_files_shared_tools.R
@@ -98,3 +98,11 @@ test_that("check_file_exists works as expected", {
 		file
 	)
 })
+
+test_that("check_file_exists is a no-op when replace = TRUE", {
+	file <- tempfile(fileext = ".txt")
+	file.create(file)
+	on.exit(unlink(file))
+	expect_no_error(check_file_exists(file, replace = TRUE))
+	expect_null(check_file_exists(file, replace = TRUE))
+})


### PR DESCRIPTION
Closes #819.

## Summary

- Add a `replace = FALSE` argument to `use_external_js_file()`,
  `use_external_css_file()`, `use_external_html_template()`,
  `use_external_file()` and `use_bundled_html()`. When `TRUE`, an
  existing file at the target location is overwritten instead of
  aborting.
- For `use_bundled_html()`, the extracted bundle directory (and any
  stale file at the same path) is also removed before re-extraction
  when `replace = TRUE` — `unzip()` does not clean it on its own.
- `check_file_exists()` gains a `replace` short-circuit and the abort
  message now mentions the option.
- Bump dev version to `0.6.0.9000`.

## NEWS.md

## New features

## Test plan

- [x] `devtools::test()` — 625 PASS, 0 FAIL.
- [x] New test covers the default-abort and `replace = TRUE` paths for
  the 4 `use_external_*` functions.
- [x] New test covers `check_file_exists(replace = TRUE)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)