### PR TITLE
feat: warn when dev scaffolding fns are called in prod mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@
   `use_bundled_html()` gain a `replace` argument. When `TRUE`, an existing
   file (or bundle directory) at the target location is overwritten instead
   of aborting (#819).
+- Development-time scaffolding helpers (`use_*`, `add_*`, `set_golem_*`)
+  now emit a warning when they are called while `{golem}` is in
+  production mode (`options('golem.app.prod' = TRUE)`), helping catch
+  accidental invocations from a deployed app (#808).
 
 # golem 0.5.1 to 0.6.0
 

--- a/R/add_ci_files.R
+++ b/R/add_ci_files.R
@@ -15,6 +15,7 @@ add_github_action <- function(
 	golem_wd = get_golem_wd(),
 	open = TRUE
 ) {
+	warn_if_in_prod_mode()
 	add_deploy_ci_(
 		template = "github-action-template.yml",
 		output = fs_path(
@@ -42,6 +43,7 @@ add_github_action <- function(
 #'
 #' @return The path to the created GitLab CI file, invisibly.
 add_gitlab_ci <- function(golem_wd = get_golem_wd(), open = TRUE) {
+	warn_if_in_prod_mode()
 	add_deploy_ci_(
 		template = "gitlab-ci-template.yml",
 		output = fs_path(golem_wd, ".gitlab-ci.yml"),

--- a/R/add_dockerfiles.R
+++ b/R/add_dockerfiles.R
@@ -119,6 +119,7 @@ add_dockerfile <- function(
 	extra_sysreqs = NULL,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -258,6 +259,7 @@ add_dockerfile_shinyproxy <- function(
 	extra_sysreqs = NULL,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -387,6 +389,7 @@ add_dockerfile_heroku <- function(
 	extra_sysreqs = NULL,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(

--- a/R/add_dockerfiles_renv.R
+++ b/R/add_dockerfiles_renv.R
@@ -270,6 +270,7 @@ add_dockerfile_with_renv <- function(
 	...,
 	source_folder
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		source_folder,
 		fun = as.character(sys.call()[[1]]),
@@ -414,6 +415,7 @@ add_dockerfile_with_renv_shinyproxy <- function(
 	...,
 	source_folder
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		source_folder,
 		fun = as.character(sys.call()[[1]]),
@@ -474,6 +476,7 @@ add_dockerfile_with_renv_heroku <- function(
 	...,
 	source_folder
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		source_folder,
 		fun = as.character(sys.call()[[1]]),

--- a/R/add_files.R
+++ b/R/add_files.R
@@ -41,6 +41,7 @@ add_js_file <- function(
 	...,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -109,6 +110,7 @@ add_js_handler <- function(
 	...,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -357,6 +359,7 @@ add_js_input_binding <- function(
 	),
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -663,6 +666,7 @@ add_js_output_binding <- function(
 	dir_create,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -828,6 +832,7 @@ add_css_file <- function(
 	...,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -879,6 +884,7 @@ add_sass_file <- function(
 	...,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -983,6 +989,7 @@ add_empty_file <- function(
 	...,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -1092,6 +1099,7 @@ add_html_template <- function(
 	dir_create,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -1167,6 +1175,7 @@ add_partial_html_template <- function(
 	dir_create,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -1218,6 +1227,7 @@ add_ui_server_files <- function(
 	dir_create,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(

--- a/R/add_r_files.R
+++ b/R/add_r_files.R
@@ -222,6 +222,7 @@ add_fct <- function(
 	...,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -253,6 +254,7 @@ add_utils <- function(
 	with_test = FALSE,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -282,6 +284,7 @@ add_r6 <- function(
 	with_test = FALSE,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(

--- a/R/add_rstudio_files.R
+++ b/R/add_rstudio_files.R
@@ -176,6 +176,7 @@ add_positconnect_file <- function(
 	open = TRUE,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -197,6 +198,7 @@ add_shinyappsio_file <- function(
 	open = TRUE,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -218,6 +220,7 @@ add_shinyserver_file <- function(
 	open = TRUE,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -239,6 +242,7 @@ add_rscignore_file <- function(
 	open = TRUE,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(

--- a/R/golem-yaml-set.R
+++ b/R/golem-yaml-set.R
@@ -7,6 +7,7 @@ set_golem_wd <- function(
 	golem_wd,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		golem_wd,
 		fun = as.character(
@@ -65,6 +66,7 @@ set_golem_name <- function(
 	old_name = golem::pkg_name(),
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -237,6 +239,7 @@ set_golem_version <- function(
 	talkative = TRUE,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(

--- a/R/make_dev.R
+++ b/R/make_dev.R
@@ -13,7 +13,10 @@ warn_if_in_prod_mode <- function() {
 	}
 	fun_call <- sys.call(-1)
 	fun_name <- if (length(fun_call)) {
-		as.character(fun_call[[1L]])
+		# deparse() (rather than as.character()) keeps the call's textual
+		# form intact for namespaced invocations like `golem::use_*()`,
+		# which would otherwise be returned as c("::", "golem", "use_*").
+		deparse(fun_call[[1L]])
 	} else {
 		"This function"
 	}

--- a/R/make_dev.R
+++ b/R/make_dev.R
@@ -1,3 +1,32 @@
+#' Warn if called while {golem} is in production mode
+#'
+#' Helper used by development-time scaffolding functions (`use_*`,
+#' `add_*`, `set_golem_*`) to alert the user when they are accidentally
+#' invoked from a running app (i.e. when `options('golem.app.prod')` is
+#' `TRUE`).
+#'
+#' @return Used for its side-effect (prints a `cli` warning).
+#' @noRd
+warn_if_in_prod_mode <- function() {
+	if (!isTRUE(getOption("golem.app.prod"))) {
+		return(invisible(NULL))
+	}
+	fun_call <- sys.call(-1)
+	fun_name <- if (length(fun_call)) {
+		as.character(fun_call[[1L]])
+	} else {
+		"This function"
+	}
+	warning(
+		sprintf(
+			"`%s()` is a development function and should not be called when {golem} is in production mode (`options('golem.app.prod' = TRUE)`).",
+			fun_name
+		),
+		call. = FALSE
+	)
+	invisible(NULL)
+}
+
 #' Make a function dependent to dev mode
 #'
 #' The function returned will be run only if `golem::app_dev()`

--- a/R/modules_fn.R
+++ b/R/modules_fn.R
@@ -42,6 +42,7 @@ add_module <- function(
 	...,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(

--- a/R/set_golem_options.R
+++ b/R/set_golem_options.R
@@ -46,6 +46,7 @@ set_golem_options <- function(
 	talkative = TRUE,
 	config_file = golem::get_current_config(golem_wd)
 ) {
+	warn_if_in_prod_mode()
 	# TODO here we'll run the
 	# golem_install_dev_pkg() function
 

--- a/R/use_agent_skills.R
+++ b/R/use_agent_skills.R
@@ -175,6 +175,7 @@ use_skills <- function(
 	golem_wd = get_golem_wd(),
 	interactive = rlang_is_interactive()
 ) {
+	warn_if_in_prod_mode()
 	use_agent_implement(
 		source = source,
 		agent_specs = agent_specs,
@@ -203,6 +204,7 @@ use_agent_skills <- function(
 	golem_wd = get_golem_wd(),
 	interactive = rlang_is_interactive()
 ) {
+	warn_if_in_prod_mode()
 	use_agent_implement(
 		source = source,
 		agent_specs = "agents",
@@ -231,6 +233,7 @@ use_claude_skills <- function(
 	golem_wd = get_golem_wd(),
 	interactive = rlang_is_interactive()
 ) {
+	warn_if_in_prod_mode()
 	use_agent_implement(
 		source = source,
 		agent_specs = "claude",
@@ -265,6 +268,7 @@ use_skill <- function(
 	golem_wd = get_golem_wd(),
 	interactive = rlang_is_interactive()
 ) {
+	warn_if_in_prod_mode()
 	if (missing(name) || length(name) != 1 || !nzchar(name)) {
 		cli_abort("`name` must be a single non-empty skill name.")
 	}

--- a/R/use_favicon.R
+++ b/R/use_favicon.R
@@ -21,6 +21,7 @@ use_favicon <- function(
 	method = "curl",
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(

--- a/R/use_files_external.R
+++ b/R/use_files_external.R
@@ -36,6 +36,7 @@ use_external_js_file <- function(
 	pkg,
 	replace = FALSE
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -75,6 +76,7 @@ use_external_css_file <- function(
 	pkg,
 	replace = FALSE
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -115,6 +117,7 @@ use_external_html_template <- function(
 	delete_zip = c("ask", "yes", "no"),
 	replace = FALSE
 ) {
+	warn_if_in_prod_mode()
 	if (!missing(dir_create)) {
 		cli_abort_dir_create()
 	}
@@ -165,6 +168,7 @@ use_external_file <- function(
 	pkg,
 	replace = FALSE
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -204,6 +208,7 @@ use_bundled_html <- function(
 	delete_zip = c("ask", "yes", "no"),
 	replace = FALSE
 ) {
+	warn_if_in_prod_mode()
 	extract <- match.arg(extract)
 	delete_zip <- match.arg(delete_zip)
 	old <- setwd(fs_path_abs(golem_wd))

--- a/R/use_files_internal.R
+++ b/R/use_files_internal.R
@@ -9,6 +9,7 @@ use_internal_js_file <- function(
 	dir_create,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -48,6 +49,7 @@ use_internal_css_file <- function(
 	dir_create,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -87,6 +89,7 @@ use_internal_html_template <- function(
 	dir_create,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -124,6 +127,7 @@ use_internal_file <- function(
 	dir_create,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(

--- a/R/use_readme.R
+++ b/R/use_readme.R
@@ -14,6 +14,7 @@ use_readme_rmd <- function(
 	golem_wd = golem::get_golem_wd(),
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(

--- a/R/use_recommended.R
+++ b/R/use_recommended.R
@@ -21,6 +21,7 @@ use_recommended_tests <- function(
 	error = FALSE,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(

--- a/R/use_utils.R
+++ b/R/use_utils.R
@@ -18,6 +18,7 @@ use_utils_ui <- function(
 	with_test = FALSE,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -76,6 +77,7 @@ use_utils_test_ui <- function(
 	golem_wd = get_golem_wd(),
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -103,6 +105,7 @@ use_utils_server <- function(
 	with_test = FALSE,
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(
@@ -204,6 +207,7 @@ use_utils_test_server <- function(
 	golem_wd = get_golem_wd(),
 	pkg
 ) {
+	warn_if_in_prod_mode()
 	signal_arg_is_deprecated(
 		pkg,
 		fun = as.character(

--- a/tests/testthat/test-make_dev.R
+++ b/tests/testthat/test-make_dev.R
@@ -82,6 +82,61 @@ test_that("test make_dev", {
 	)
 })
 
+test_that("warn_if_in_prod_mode warns only when golem.app.prod is TRUE", {
+	withr::with_options(
+		c(golem.app.prod = TRUE),
+		{
+			caller <- function() warn_if_in_prod_mode()
+			expect_warning(
+				caller(),
+				"`caller\\(\\)` is a development function"
+			)
+		}
+	)
+	withr::with_options(
+		c(golem.app.prod = FALSE),
+		{
+			caller <- function() warn_if_in_prod_mode()
+			expect_no_warning(caller())
+		}
+	)
+	withr::with_options(
+		c(golem.app.prod = NULL),
+		{
+			caller <- function() warn_if_in_prod_mode()
+			expect_no_warning(caller())
+		}
+	)
+})
+
+test_that("dev scaffolding functions warn when called in prod mode", {
+	# Representative samples from each in-scope family. We don't run the
+	# real bodies — we only assert that the prod-mode warning fires at the
+	# entry of the function.
+	check_warns <- function(expr) {
+		withr::with_options(
+			c(golem.app.prod = TRUE),
+			expect_warning(
+				suppressMessages(try(expr, silent = TRUE)),
+				"development function"
+			)
+		)
+	}
+	check_warns(use_external_file(
+		url = "http://example.com/x.txt",
+		golem_wd = tempdir()
+	))
+	check_warns(add_module(
+		name = "foo",
+		golem_wd = tempdir(),
+		open = FALSE
+	))
+	check_warns(set_golem_name(
+		name = "foo",
+		golem_wd = tempdir()
+	))
+})
+
 test_that("test browser_button", {
 	withr::with_options(
 		c("golem.quiet" = FALSE),

--- a/tests/testthat/test-make_dev.R
+++ b/tests/testthat/test-make_dev.R
@@ -109,10 +109,31 @@ test_that("warn_if_in_prod_mode warns only when golem.app.prod is TRUE", {
 	)
 })
 
+test_that("warn_if_in_prod_mode preserves the caller name for `pkg::fun` calls", {
+	withr::with_options(
+		c(golem.app.prod = TRUE),
+		{
+			# The real body errors out further down (no real golem project
+			# under the tempdir); we only care about the warning text.
+			expect_warning(
+				try(
+					golem::use_external_file(
+						url = "http://example.com/x.txt",
+						golem_wd = withr::local_tempdir()
+					),
+					silent = TRUE
+				),
+				"`golem::use_external_file\\(\\)` is a development function"
+			)
+		}
+	)
+})
+
 test_that("dev scaffolding functions warn when called in prod mode", {
 	# Representative samples from each in-scope family. We don't run the
 	# real bodies — we only assert that the prod-mode warning fires at the
-	# entry of the function.
+	# entry of the function. Each call runs against an isolated tempdir so
+	# we don't leak files between tests.
 	check_warns <- function(expr) {
 		withr::with_options(
 			c(golem.app.prod = TRUE),
@@ -124,16 +145,16 @@ test_that("dev scaffolding functions warn when called in prod mode", {
 	}
 	check_warns(use_external_file(
 		url = "http://example.com/x.txt",
-		golem_wd = tempdir()
+		golem_wd = withr::local_tempdir()
 	))
 	check_warns(add_module(
 		name = "foo",
-		golem_wd = tempdir(),
+		golem_wd = withr::local_tempdir(),
 		open = FALSE
 	))
 	check_warns(set_golem_name(
 		name = "foo",
-		golem_wd = tempdir()
+		golem_wd = withr::local_tempdir()
 	))
 })
 


### PR DESCRIPTION
Closes #808.

## Summary

- New internal helper `warn_if_in_prod_mode()` in [R/make_dev.R](R/make_dev.R) emits a `warning()` whenever `getOption('golem.app.prod')` is `TRUE`. The caller name is inferred via `sys.call(-1)`, so the message reads like ``\`use_external_file()\` is a development function and should not be called when {golem} is in production mode``.
- Wired into 50 exported scaffolding functions across the `use_*`, `add_*` and `set_golem_*` families. `add_resource_path()` is intentionally left out since it is part of the runtime, not the scaffolding.
- Tests cover the helper in isolation (TRUE / FALSE / NULL cases) and three representative call sites (`use_external_file()`, `add_module()`, `set_golem_name()`).

## NEWS.md

## New features

## Test plan

- [x] `devtools::test()` — 637 PASS, 0 FAIL.
- [x] `devtools::check()` — 0 errors, 0 warnings, 1 environmental NOTE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)